### PR TITLE
Implement tx/supports-time-type? for tests

### DIFF
--- a/.github/deps.edn
+++ b/.github/deps.edn
@@ -655,7 +655,7 @@
      metabase.api.table-test/query-metadata-remappings-test
      metabase.api.table-test/related-test
      metabase.api.table-test/get-fks-test
-     ;metabase.api.table-test/datetime-binning-options-test
+     metabase.api.table-test/datetime-binning-options-test
      metabase.api.table-test/sensitive-fields-included-test
      metabase.api.table-test/sensitive-fields-not-included-test
      metabase.api.table-test/fk-target-permissions-test

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -70,3 +70,5 @@
 (defmethod sql.tx/pk-sql-type :clickhouse [_] "Nullable(Int32)")
 
 (defmethod sql.tx/add-fk-sql :clickhouse [& _] nil) ; TODO - fix me
+
+(defmethod tx/supports-time-type? :clickhouse [_driver] false)


### PR DESCRIPTION
Allows to uncomment `datetime-binning-options-test` for CI as it does not fail now.