### PR TITLE
Skip tests setting the JVM timezone

### DIFF
--- a/.github/deps.edn
+++ b/.github/deps.edn
@@ -2078,8 +2078,8 @@
      metabase.query-processor-test.count-where-test/segment-test
      metabase.query-processor-test.count-where-test/metric-test
      metabase.query-processor-test.count-where-test/breakout-test
-     metabase.query-processor-test.date-bucketing-test/group-by-default-test
      metabase.query-processor-test.date-bucketing-test/week-of-year-and-week-count-should-be-consistent-test
+     metabase.query-processor-test.date-bucketing-test/group-by-default-test
      metabase.query-processor-test.date-bucketing-test/legacy-default-datetime-bucketing-test
      metabase.query-processor-test.date-bucketing-test/june-31st-test
      metabase.query-processor-test.date-bucketing-test/sanity-check-test

--- a/.github/deps.edn
+++ b/.github/deps.edn
@@ -2079,7 +2079,7 @@
      metabase.query-processor-test.count-where-test/metric-test
      metabase.query-processor-test.count-where-test/breakout-test
      ;metabase.query-processor-test.date-bucketing-test/week-of-year-and-week-count-should-be-consistent-test
-     ;metabase.query-processor-test.date-bucketing-test/group-by-default-test
+     metabase.query-processor-test.date-bucketing-test/group-by-default-test
      metabase.query-processor-test.date-bucketing-test/legacy-default-datetime-bucketing-test
      metabase.query-processor-test.date-bucketing-test/june-31st-test
      metabase.query-processor-test.date-bucketing-test/sanity-check-test
@@ -2087,7 +2087,7 @@
      metabase.query-processor-test.date-bucketing-test/filter-by-current-quarter-test
      metabase.query-processor-test.date-bucketing-test/default-bucketing-test
      metabase.query-processor-test.date-bucketing-test/group-by-day-of-month-test
-     ;metabase.query-processor-test.date-bucketing-test/group-by-day-test
+     metabase.query-processor-test.date-bucketing-test/group-by-day-test
      metabase.query-processor-test.date-bucketing-test/group-by-month-test
      metabase.query-processor-test.date-bucketing-test/group-by-quarter-test
      metabase.query-processor-test.date-bucketing-test/group-by-week-test
@@ -2824,4 +2824,3 @@
      metabase.types-test/coercion-strategies-test
      metabase.types-test/coercion-possibilities-test
      metabase.driver.clickhouse-test]}}}}
-

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -526,6 +526,7 @@
 (defmethod driver/supports? [:clickhouse :standard-deviation-aggregations] [_ _] true)
 (defmethod driver/supports? [:clickhouse :set-timezone] [_ _] false)
 (defmethod driver/supports? [:clickhouse :foreign-keys] [_ _] (not config/is-test?))
+(defmethod driver/supports? [:clickhouse :test/jvm-timezone-setting] [_ _] false)
 
 (defmethod sql-jdbc.sync/db-default-timezone :clickhouse
   [_ spec]


### PR DESCRIPTION
This PR relies on the driver feature setting `:test/jvm-timezone-setting` which is available on the `master` branch of `metabase/metabase`. Don't merge this if you want to be compatible with a released version of Metabase.

After merging this PR, tests agains metabase master should pass.