### PR TITLE
Add client_name JDBC setting, prepare 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# 1.0.0
+
+Formal stable release milestone.
+
+### New features
+
+* Added HTTP User-Agent (via clickhouse-jdbc `client_name` setting) with the plugin info according to the [language client spec](https://docs.google.com/document/d/1924Dvy79KXIhfqKpi1EBVY3133pIdoMwgCQtZ-uhEKs/edit#heading=h.ah33hoz5xei2)
+
+# 0.9.2
+
+### New features
+
+* Allow to bypass system-wide proxy settings [#120](https://github.com/ClickHouse/metabase-clickhouse-driver/pull/120)
+
+It's the first plugin release from the ClickHouse organization.
+
+From now on, the plugin is distributed under the Apache 2.0 License.
+
+# 0.9.1
+
+### New features
+
+* Metabase 0.45.x compatibility [#107](https://github.com/ClickHouse/metabase-clickhouse-driver/pull/107)
+* Added SSH tunnel option [#116](https://github.com/ClickHouse/metabase-clickhouse-driver/pull/116)
+
+# 0.9.0
+
+### New features
+
+* Using https://github.com/ClickHouse/clickhouse-jdbc `v0.3.2-patch11`
+
+### Bug fixes
+
+* URLs with underscores [#23](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/23)
+* `now()` timezones issues [#81](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/81)
+* Boolean errors [#88](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/88)
+
+NB: there are messages like this in the Metabase logs
+
+```
+2022-12-07 11:20:58,056 WARN internal.ClickHouseConnectionImpl :: [JDBC Compliant Mode] Transaction is not supported. You may change jdbcCompliant to false to throw SQLException instead.
+2022-12-07 11:20:58,056 WARN internal.ClickHouseConnectionImpl :: [JDBC Compliant Mode] Transaction [ce0e121a-419a-4414-ac39-30f79eff7afd] (0 queries & 0 savepoints) is committed.
+```
+
+Unfortunately, this is the behaviour of the underlying JDBC driver now.
+
+Please consider raising the log level for `com.clickhouse.jdbc.internal.ClickHouseConnectionImpl` to `ERROR`.
+
+# 0.8.3
+
+### New features
+
+* Enable additional options for ClickHouse connection
+
+# 0.8.2
+
+### New features
+
+* Compatibility with Metabase 0.44

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Metabase Release | Driver Version
 0.41.2           | 0.8.0
 0.41.3.1         | 0.8.1
 0.42.x           | 0.8.1
-0.44.x           | 0.9.2
-0.45.x           | 0.9.2
+0.44.x           | 0.9.1
+0.45.x           | 1.0.0
 
 ## Creating a Metabase Docker image with ClickHouse driver
 

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 0.9.2
+  version: 1.0.0
   description: Allows Metabase to connect to ClickHouse databases.
 driver:
   name: clickhouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -83,7 +83,9 @@
     :user user
     :ssl (boolean ssl)
     :use_no_proxy (boolean use-no-proxy)
-    :use_server_time_zone_for_dates true}
+    :use_server_time_zone_for_dates true
+    ;; temporary hardcode until we get product_name setting with JDBC driver v0.4.0
+    :client_name "metabase/1.0.0 clickhouse-jdbc/0.3.2-patch-11"}
    (sql-jdbc.common/handle-additional-options details :separator-style :url)))
 
 (defn- to-relative-day-num

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -481,7 +481,8 @@
           :password ""
           :ssl false
           :use_no_proxy false
-          :use_server_time_zone_for_dates true}
+          :use_server_time_zone_for_dates true
+          :client_name "metabase/1.0.0 clickhouse-jdbc/0.3.2-patch-11"}
          (sql-jdbc.conn/connection-details->spec
           :clickhouse
           {:host "localhost"
@@ -497,7 +498,8 @@
           :password ""
           :ssl false
           :use_no_proxy true
-          :use_server_time_zone_for_dates true}
+          :use_server_time_zone_for_dates true
+          :client_name "metabase/1.0.0 clickhouse-jdbc/0.3.2-patch-11"}
          (sql-jdbc.conn/connection-details->spec
           :clickhouse
           {:host "localhost"


### PR DESCRIPTION
## Summary
1.0.0 is our formal stable release milestone.

* Added HTTP User-Agent (via clickhouse-jdbc `client_name` setting) with the plugin info according to the [language client spec](https://docs.google.com/document/d/1924Dvy79KXIhfqKpi1EBVY3133pIdoMwgCQtZ-uhEKs/edit#heading=h.ah33hoz5xei2). For now it's just `metabase/1.0.0 clickhouse-jdbc/0.3.2-patch-11`, OS and runtime info will be appended after we upgrade to the JDBC v0.4.0 and use `product_name` setting instead.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
