### PR TITLE
Add "Scan all databases" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### New features
 
-* Added "Scan all databases" toggle on the UI. Enabling it brings legacy driver behaviour where it scans all available databases, excluding `system` and `information_schema`.
+* Adds a new "Scan all databases" UI toggle (disabled by default), which tells the driver to scan all available databases (excluding `system` and `information_schema`) instead of only the database it is connected to.
+* Database input moved below host/port/username/password in the UI.
 
 # 1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.4
+
+### New features
+
+* Added "Scan all databases" toggle on the UI. Enabling it brings legacy driver behaviour where it scans all available databases, excluding `system` and `information_schema`.
+
 # 1.0.3
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Metabase Release | Driver Version
 0.41.3.1         | 0.8.1
 0.42.x           | 0.8.1
 0.44.x           | 0.9.1
-0.45.x           | 1.0.3
+0.45.x           | 1.0.4
 
 ## Creating a Metabase Docker image with ClickHouse driver
 

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -11,15 +11,19 @@ driver:
   lazy-load: true
   parent: sql-jdbc
   connection-properties:
-    - name: dbname
-      display-name: Database Name
-      placeholder: default
     - host
     - merge:
         - port
         - default: 8123
     - user
     - password
+    - name: dbname
+      display-name: Database Name
+      placeholder: default
+    - name: scan-all-databases
+      display-name: Scan all databases
+      type: boolean
+      default: false
     - ssl
     - ssh-tunnel
     - advanced-options-start

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -13,7 +13,7 @@
 
 (sql-jdbc.tx/add-test-extensions! :clickhouse)
 
-(def product-name "metabase/1.0.3 clickhouse-jdbc/0.3.2-patch-11")
+(def product-name "metabase/1.0.4 clickhouse-jdbc/0.3.2-patch-11")
 (def default-connection-params {:classname "com.clickhouse.jdbc.ClickHouseDriver"
                                 :subprotocol "clickhouse"
                                 :subname "//localhost:8123/default"


### PR DESCRIPTION
## Summary
Resolves #137 #121 

Adds a new "Scan all databases" UI toggle (disabled by default), which tells the driver to scan all available databases instead of only the database it is connected to.

Database input moved below host/port/username/password as it seems more logical.

![image](https://user-images.githubusercontent.com/3175289/219295939-c7d49147-433a-4375-bbf8-adce95c072f1.png)

As a result, we can see all the databases as schemas in the data browser:

![image](https://user-images.githubusercontent.com/3175289/219295841-c9b4a1bd-563e-4ee2-9652-63cef3a7472c.png)

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
