### PR TITLE
Upgrade JDBC driver to v0.4.1

### DIFF
--- a/.github/deps.edn
+++ b/.github/deps.edn
@@ -1397,7 +1397,6 @@
      metabase.models.pulse-channel-test/update-pulse-channel!-test
      metabase.models.pulse-channel-test/retrieve-scheduled-channels-test
      metabase.models.pulse-test/update-pulse-test
-     metabase.models.pulse-test/no-permissions-test
      metabase.models.pulse-test/create-dashboard-subscription-test
      metabase.models.pulse-test/no-archived-cards-test
      metabase.models.pulse-test/validate-collection-namespace-test
@@ -1408,7 +1407,6 @@
      metabase.models.pulse-test/retrieve-pulse-test
      metabase.models.pulse-test/dashboard-subscription-update-test
      metabase.models.pulse-test/update-notification-channels-test
-     metabase.models.pulse-test/has-permissions-test
      metabase.models.pulse-test/create-pulse-test
      metabase.models.query.permissions-test/nested-query-test
      metabase.models.query.permissions-test/invalid-queries-test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.45.2
+          ref: v0.45.3
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.1.0
+
+### New features
+
+* Update JDBC driver to v0.4.1.
+* Use new `product_name` additional option instead of `client_name`
+* Replace `sql-jdbc.execute/read-column [:clickhouse Types/ARRAY]` with `sql-jdbc.execute/read-column-thunk [:clickhouse Types/ARRAY]` to be compatible with Metabase 0.46 breaking changes once it is released.
+
+### Bug fixes
+
+* Fix `sql-jdbc.execute/read-column-thunk [:clickhouse Types/TIME]` return type.
+
 # 1.0.4
 
 ### New features

--- a/deps.edn
+++ b/deps.edn
@@ -3,6 +3,6 @@
 
  :deps
  {com.clickhouse/clickhouse-jdbc$http
-  {:mvn/version "0.3.2-patch11"
+  {:mvn/version "0.4.1"
    :exclusions [com.clickhouse/clickhouse-cli-client$shaded
                 com.clickhouse/clickhouse-grpc-client$shaded]}}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     hostname: server.clickhouseconnect.test
 
   metabase:
-    image: metabase/metabase:v0.45.2
+    image: metabase/metabase:v0.45.3
     container_name: metabase-with-clickhouse-driver
     ports:
       - '3000:3000'

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.0.4
+  version: 1.1.0
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -74,7 +74,7 @@
 
 (def ^:private default-connection-details
   {:user "default", :password "", :dbname "default", :host "localhost", :port "8123"})
-(def ^:private product-name "metabase/1.0.5")
+(def ^:private product-name "metabase/1.1.0")
 
 (defmethod sql-jdbc.conn/connection-details->spec :clickhouse
   [_ details]

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -21,7 +21,7 @@
                                 :ssl false
                                 :use_no_proxy false
                                 :use_server_time_zone_for_dates true
-                                :product_name "metabase/1.0.5"})
+                                :product_name "metabase/1.1.0"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -13,7 +13,6 @@
 
 (sql-jdbc.tx/add-test-extensions! :clickhouse)
 
-(def product-name "metabase/1.0.4 clickhouse-jdbc/0.3.2-patch-11")
 (def default-connection-params {:classname "com.clickhouse.jdbc.ClickHouseDriver"
                                 :subprotocol "clickhouse"
                                 :subname "//localhost:8123/default"
@@ -22,7 +21,7 @@
                                 :ssl false
                                 :use_no_proxy false
                                 :use_server_time_zone_for_dates true
-                                :client_name product-name})
+                                :product_name "metabase/1.0.5"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")


### PR DESCRIPTION
## Summary
* Update JDBC driver to v0.4.1
* Use new `product_name` additional option instead of `client_name`
* Fix `sql-jdbc.execute/read-column-thunk [:clickhouse Types/TIME]` return type
* Replace `sql-jdbc.execute/read-column [:clickhouse Types/ARRAY]` with `sql-jdbc.execute/read-column-thunk [:clickhouse Types/ARRAY]` to be compatible with Metabase 0.46 breaking changes once it is released

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
