### PR TITLE
Scan SimpleAggregateFunction columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.1.2
+
+### Bug fixes
+
+* Now the driver is able to scan and work with `SimpleAggregateFunction` columns: those were excluded by mistake in 1.0.2.
+
+
 # 1.1.1
 
 ### New features

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.1.1
+  version: 1.1.2
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -74,7 +74,7 @@
 
 (def ^:private default-connection-details
   {:user "default", :password "", :dbname "default", :host "localhost", :port "8123"})
-(def ^:private product-name "metabase/1.1.1")
+(def ^:private product-name "metabase/1.1.2")
 
 (defmethod sql-jdbc.conn/connection-details->spec :clickhouse
   [_ details]
@@ -161,9 +161,9 @@
                                     (update-in field [:database-type]
                                                ;; Enum8(UInt8) -> Enum8
                                                clojure.string/replace #"^(Enum.+)\(.+\)" "$1")]
-                              ;; Skip all (Simple)AggregateFunction columns
+                              ;; Skip all AggregateFunction (but keeping SimpleAggregateFunction) columns
                               ;; JDBC does not support that and it crashes the data browser
-                              :when (not (re-matches #"^.*AggregateFunction\(.+$"
+                              :when (not (re-matches #"^AggregateFunction\(.+$"
                                                      (get field :database-type)))]
                           updated-field)]
     (merge table-metadata {:fields (set filtered-fields)})))

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -511,20 +511,30 @@
    (testing "(Simple)AggregateFunction columns are filtered"
      (testing "from the table metadata"
        (is (= {:name "aggregate_functions_filter_test"
-               :fields #{{:name "i"
+               :fields #{{:name "idx"
                           :database-type "UInt8"
                           :base-type :type/Integer
                           :database-position 0
                           ; TODO: in Metabase 0.45.0-RC this returned true,
                           ; and now it is false, which is strange, cause it is not Nullable in the DDL
+                          :database-required false}
+                         {:name "lowest_value"
+                          :database-type "SimpleAggregateFunction(min, UInt8)",
+                          :base-type :type/Integer,
+                          :database-position 2,
+                          :database-required false}
+                         {:name "count"
+                          :database-type "SimpleAggregateFunction(sum, Int64)",
+                          :base-type :type/BigInteger,
+                          :database-position 3,
                           :database-required false}}}
               (ctu/do-with-metabase-test-db
                (fn [db]
                  (driver/describe-table :clickhouse db {:name "aggregate_functions_filter_test"}))))))
      (testing "from the result set"
-       (is (= [[42]]
+       (is (= [[42 144 255255]]
               (qp.test/formatted-rows
-               [int]
+               [int int int]
                :format-nil-values
                (ctu/do-with-metabase-test-db
                 (fn [db]

--- a/test/metabase/driver/clickhouse_test_utils.clj
+++ b/test/metabase/driver/clickhouse_test_utils.clj
@@ -57,9 +57,11 @@
                       " (2, false, true),"
                       " (3, true, false);")
                  (str "CREATE TABLE `metabase_test`.`aggregate_functions_filter_test` ("
-                      " i UInt8, a AggregateFunction(uniq, String), b SimpleAggregateFunction(min, UInt8)"
+                      " idx UInt8, a AggregateFunction(uniq, String), lowest_value SimpleAggregateFunction(min, UInt8),"
+                      " count SimpleAggregateFunction(sum, Int64)"
                       ") ENGINE Memory;")
-                 (str "INSERT INTO `metabase_test`.`aggregate_functions_filter_test` (i) VALUES (42);")]]
+                 (str "INSERT INTO `metabase_test`.`aggregate_functions_filter_test`"
+                      " (idx, lowest_value, count) VALUES (42, 144, 255255);")]]
       (jdbc/execute! conn [sql]))))
 
 (defn do-with-metabase-test-db

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -21,7 +21,7 @@
                                 :ssl false
                                 :use_no_proxy false
                                 :use_server_time_zone_for_dates true
-                                :product_name "metabase/1.1.1"})
+                                :product_name "metabase/1.1.2"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")


### PR DESCRIPTION
## Summary
### Bug fixes

* Now the driver is able to scan and work with `SimpleAggregateFunction` columns: those were excluded by mistake in 1.0.2.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

