### PR TITLE
WIP: Exclude .inner MV tables, set Dictionary types for Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+# 1.1.3
+
+### New features
+
+* Hide `.inner` tables of Materialized Views.
+
 # 1.1.2
 
 ### Bug fixes

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.1.2
+  version: 1.1.3
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -439,6 +439,21 @@
                  {:filter [:= $ipvfour "127.0.0.1"]
                   :aggregation [:count]})))))))))
 
+(defn- map-as-string [^java.util.LinkedHashMap m] (.toString m))
+(deftest clickhouse-simple-map-test
+  (mt/test-driver
+   :clickhouse
+   (is (= [["{key1=1, key2=10}"] ["{key1=2, key2=20}"] ["{key1=3, key2=30}"]]
+          (qp.test/formatted-rows
+           [map-as-string]
+           :format-nil-values
+           (ctu/do-with-metabase-test-db
+            (fn [db]
+              (data/with-db db
+                (data/run-mbql-query
+                 maps_test
+                 {})))))))))
+
 (deftest clickhouse-connection-string
   (testing "connection with no additional options"
     (is (= default-connection-params
@@ -482,8 +497,9 @@
 (deftest clickhouse-boolean-tabledef-metadata
   (mt/test-driver
    :clickhouse
-   (let [table_md      (ctu/do-with-metabase-test-db
-                        (fn [db] (metabase.driver/describe-table :clickhouse db {:name "boolean_test"})))
+   (let [table_md (ctu/do-with-metabase-test-db
+                   (fn [db]
+                     (metabase.driver/describe-table :clickhouse db {:name "boolean_test"})))
          colmap        (->> (.get table_md :fields)
                             (filter #(= (:name %) "b1")) first)
          database-type (.get colmap :database-type)
@@ -545,26 +561,28 @@
                      {})))))))))))
 
 (deftest clickhouse-describe-database
-  (let [[agg-fn-table boolean-table enum-table
-         ipaddress-table wikistat-table wikistat-mv]
-        [{:description nil,
-          :name "aggregate_functions_filter_test",
-          :schema "metabase_test"}
-         {:description nil,
-          :name "boolean_test",
-          :schema "metabase_test"}
-         {:description nil,
-          :name "enums_test",
-          :schema "metabase_test"}
-         {:description nil,
-          :name "ipaddress_test",
-          :schema "metabase_test"}
-         {:description nil,
-          :name "wikistat",
-          :schema "metabase_test"}
-         {:description nil,
-          :name "wikistat_mv",
-          :schema "metabase_test"}]]
+  (let [test-tables
+        #{{:description nil,
+           :name "aggregate_functions_filter_test",
+           :schema "metabase_test"}
+          {:description nil,
+           :name "boolean_test",
+           :schema "metabase_test"}
+          {:description nil,
+           :name "enums_test",
+           :schema "metabase_test"}
+          {:description nil,
+           :name "ipaddress_test",
+           :schema "metabase_test"}
+          {:description nil,
+           :name "wikistat",
+           :schema "metabase_test"}
+          {:description nil,
+           :name "wikistat_mv",
+           :schema "metabase_test"}
+          {:description nil,
+           :name "maps_test",
+           :schema "metabase_test"}}]
     (testing "scanning a single database"
       (mt/with-temp Database
         [db {:engine :clickhouse
@@ -572,8 +590,7 @@
                        :scan-all-databases nil}}]
         (let [describe-result (driver/describe-database :clickhouse db)]
           (is (=
-               {:tables
-                #{agg-fn-table boolean-table enum-table ipaddress-table wikistat-table wikistat-mv}}
+               {:tables test-tables}
                describe-result))))
       (testing "scanning all databases"
         (mt/with-temp Database
@@ -582,18 +599,9 @@
                          :scan-all-databases true}}]
           (let [describe-result (driver/describe-database :clickhouse db)]
             ;; check the existence of at least some test tables here
-            (is (contains? (:tables describe-result)
-                           agg-fn-table))
-            (is (contains? (:tables describe-result)
-                           boolean-table))
-            (is (contains? (:tables describe-result)
-                           enum-table))
-            (is (contains? (:tables describe-result)
-                           ipaddress-table))
-            (is (contains? (:tables describe-result)
-                           wikistat-table))
-            (is (contains? (:tables describe-result)
-                           wikistat-mv))
+            (doseq [table test-tables]
+              (is (contains? (:tables describe-result)
+                             table)))
             ;; should not contain any ClickHouse system tables
             (is (not (some #(= (:schema %) "system")
                            (:tables describe-result))))

--- a/test/metabase/driver/clickhouse_test_utils.clj
+++ b/test/metabase/driver/clickhouse_test_utils.clj
@@ -56,12 +56,19 @@
                       " (1, true, true),"
                       " (2, false, true),"
                       " (3, true, false);")
+                 (str "CREATE TABLE `metabase_test`.`maps_test`"
+                      " (m Map(String, UInt64)) ENGINE = Memory;")
+                 (str "INSERT INTO `metabase_test`.`maps_test` VALUES"
+                      " ({'key1':1, 'key2':10}), ({'key1':2,'key2':20}), ({'key1':3,'key2':30});")
+                 ;; Used for testing that AggregateFunction columns are excluded,
+                 ;; while SimpleAggregateFunction columns are preserved
                  (str "CREATE TABLE `metabase_test`.`aggregate_functions_filter_test` ("
                       " idx UInt8, a AggregateFunction(uniq, String), lowest_value SimpleAggregateFunction(min, UInt8),"
                       " count SimpleAggregateFunction(sum, Int64)"
                       ") ENGINE Memory;")
                  (str "INSERT INTO `metabase_test`.`aggregate_functions_filter_test`"
                       " (idx, lowest_value, count) VALUES (42, 144, 255255);")
+                 ;; Materialized views (testing .inner tables exclusion)
                  (str "CREATE TABLE `metabase_test`.`wikistat` ("
                       " `date` Date,"
                       " `project` LowCardinality(String),"

--- a/test/metabase/driver/clickhouse_test_utils.clj
+++ b/test/metabase/driver/clickhouse_test_utils.clj
@@ -61,7 +61,19 @@
                       " count SimpleAggregateFunction(sum, Int64)"
                       ") ENGINE Memory;")
                  (str "INSERT INTO `metabase_test`.`aggregate_functions_filter_test`"
-                      " (idx, lowest_value, count) VALUES (42, 144, 255255);")]]
+                      " (idx, lowest_value, count) VALUES (42, 144, 255255);")
+                 (str "CREATE TABLE `metabase_test`.`wikistat` ("
+                      " `date` Date,"
+                      " `project` LowCardinality(String),"
+                      " `hits` UInt32"
+                      ") ENGINE = Memory;")
+                 (str "CREATE MATERIALIZED VIEW `metabase_test`.`wikistat_mv` ENGINE=Memory AS"
+                      " SELECT date, project, sum(hits) AS hits FROM `metabase_test`.`wikistat`"
+                      " GROUP BY date, project;")
+                 (str "INSERT INTO `metabase_test`.`wikistat` VALUES"
+                      " (now(), 'foo', 10),"
+                      " (now(), 'bar', 10),"
+                      " (now(), 'bar', 20);")]]
       (jdbc/execute! conn [sql]))))
 
 (defn do-with-metabase-test-db

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -21,7 +21,7 @@
                                 :ssl false
                                 :use_no_proxy false
                                 :use_server_time_zone_for_dates true
-                                :product_name "metabase/1.1.2"})
+                                :product_name "metabase/1.1.3"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")


### PR DESCRIPTION
## Summary
* Set Dictionary type for Maps (see #119) - needs clarification
* Exclude `.inner` MV tables (resolves #149)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
