### PR TITLE
feature: Add DateTime with timezone support

### DIFF
--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -178,8 +178,8 @@
         filtered-fields (for [field (:fields table-metadata)
                               :let [updated-field
                                     (update-in field [:database-type]
-                                               ;; Enum8(UInt8) -> Enum8
-                                               clojure.string/replace #"^(Enum.+)\(.+\)" "$1")]
+                                               ;; Enum8(UInt8) -> Enum8, DateTime(String) -> DateTime
+                                               clojure.string/replace #"((?:Enum|DateTime)\d*)(?:(.+))?" "$1")]
                               ;; Skip all AggregateFunction (but keeping SimpleAggregateFunction) columns
                               ;; JDBC does not support that and it crashes the data browser
                               :when (not (re-matches #"^AggregateFunction\(.+$"


### PR DESCRIPTION
## Summary
Metabase builder generates condition like this on DateTime column even if local timezone is enabled:
`column_name >= parseDateTimeBestEffort('2023-03-13 00:00:00.000Z')`

For comparison, with Postgres it looks like this:
`"column_name" >= timestamp with time zone '2023-03-13 00:00:00.000-04:00'`

This PR just extends regex for column mapping to properly handle columns with type `DateTime('Timezone')`

Some tests with this regex:
https://regex101.com/r/Yahlbt/1

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
