### PR TITLE
replace the usage of u/snake-key with u/->snake_case_en

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.46.2
+          ref: v0.46.3
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     hostname: server.clickhouseconnect.test
 
   metabase:
-    image: metabase/metabase:v0.46.2
+    image: metabase/metabase:v0.46.3
     container_name: metabase-with-clickhouse-driver
     environment:
       'MB_HTTP_TIMEOUT': '5000'

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -589,4 +589,4 @@
 (defmethod driver/db-start-of-week :clickhouse [_] :monday)
 
 (defmethod ddl.i/format-name :clickhouse [_ table-or-field-name]
-  (u/snake-key table-or-field-name))
+  (u/->snake_case_en table-or-field-name))


### PR DESCRIPTION
## Summary
Clickhouse driver fails at syncing databases with the latest metabase release (version 0.46.3) with the below error: 

`java.lang.IllegalStateException: Attempting to call unbound fn: #'metabase.util/snake-key`

This is because the function `snake-key` is replaced with `->snake_case_en` in [PR](https://github.com/metabase/metabase/pull/30248)

This PR replaces the usage of the old function with the new one.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
