### PR TITLE
Fixed Nippy error with unsigned ClickHouse types

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.46.2
+          ref: v0.46.3
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.5
+
+### Bug fixes
+
+* Fixed Nippy error on cached questions (see [#147](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/147))
+
 # 1.1.4
 
 ### Bug fixes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     hostname: server.clickhouseconnect.test
 
   metabase:
-    image: metabase/metabase:v0.46.2
+    image: metabase/metabase:v0.46.3
     container_name: metabase-with-clickhouse-driver
     environment:
       'MB_HTTP_TIMEOUT': '5000'

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.1.4
+  version: 1.1.5
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -1,7 +1,8 @@
 (ns metabase.driver.clickhouse
   "Driver for ClickHouse databases"
   #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
-  (:require [clojure.java.jdbc :as jdbc]
+  (:require [metabase.driver.clickhouse-nippy]
+            [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
             [honeysql [core :as hsql] [format :as hformat]]
             [java-time :as t]
@@ -19,7 +20,6 @@
             [schema.core :as s])
   (:import [com.clickhouse.data.value ClickHouseArrayValue]
            [java.sql
-            DatabaseMetaData
             ResultSet
             ResultSetMetaData
             Types]
@@ -80,7 +80,7 @@
 
 (def ^:private default-connection-details
   {:user "default", :password "", :dbname "default", :host "localhost", :port "8123"})
-(def ^:private product-name "metabase/1.1.4")
+(def ^:private product-name "metabase/1.1.5")
 
 (defmethod sql-jdbc.conn/connection-details->spec :clickhouse
   [_ details]

--- a/src/metabase/driver/clickhouse_nippy.clj
+++ b/src/metabase/driver/clickhouse_nippy.clj
@@ -1,0 +1,47 @@
+(ns metabase.driver.clickhouse-nippy
+  (:require [taoensso.nippy :as nippy])
+  (:import  [java.io DataInput DataOutput]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; com.clickhouse.data.value.UnsignedByte
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(nippy/extend-freeze com.clickhouse.data.value.UnsignedByte :clickhouse/UnsignedByte
+                     [^com.clickhouse.data.value.UnsignedByte x ^DataOutput data-output]
+                     (nippy/freeze-to-out! data-output (.toString x)))
+
+(nippy/extend-thaw :clickhouse/UnsignedByte
+                   [^DataInput data-input]
+                   (com.clickhouse.data.value.UnsignedByte/valueOf (nippy/thaw-from-in! data-input)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; com.clickhouse.data.value.UnsignedShort
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(nippy/extend-freeze com.clickhouse.data.value.UnsignedShort :clickhouse/UnsignedShort
+                     [^com.clickhouse.data.value.UnsignedShort x ^DataOutput data-output]
+                     (nippy/freeze-to-out! data-output (.toString x)))
+
+(nippy/extend-thaw :clickhouse/UnsignedShort
+                   [^DataInput data-input]
+                   (com.clickhouse.data.value.UnsignedShort/valueOf (nippy/thaw-from-in! data-input)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; com.clickhouse.data.value.UnsignedInteger
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(nippy/extend-freeze com.clickhouse.data.value.UnsignedInteger :clickhouse/UnsignedInteger
+                     [^com.clickhouse.data.value.UnsignedInteger x ^DataOutput data-output]
+                     (nippy/freeze-to-out! data-output (.toString x)))
+
+(nippy/extend-thaw :clickhouse/UnsignedInteger
+                   [^DataInput data-input]
+                   (com.clickhouse.data.value.UnsignedInteger/valueOf (nippy/thaw-from-in! data-input)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; com.clickhouse.data.value.UnsignedLong
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(nippy/extend-freeze com.clickhouse.data.value.UnsignedLong :clickhouse/UnsignedLong
+                     [^com.clickhouse.data.value.UnsignedLong x ^DataOutput data-output]
+                     (nippy/freeze-to-out! data-output (.toString x)))
+
+(nippy/extend-thaw :clickhouse/UnsignedLong
+                   [^DataInput data-input]
+                   (com.clickhouse.data.value.UnsignedLong/valueOf (nippy/thaw-from-in! data-input)))

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -5,7 +5,6 @@
             [cljc.java-time.local-date :as local-date]
             [cljc.java-time.offset-date-time :as offset-date-time]
             [cljc.java-time.temporal.chrono-unit :as chrono-unit]
-            [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.driver.clickhouse-test-utils :as ctu]
@@ -18,7 +17,8 @@
             [metabase.test :as mt]
             [metabase.test.data :as data]
             [metabase.test.data [interface :as tx]]
-            [metabase.test.data.clickhouse :refer [default-connection-params]]))
+            [metabase.test.data.clickhouse :refer [default-connection-params]]
+            [taoensso.nippy :as nippy]))
 
 (deftest clickhouse-server-timezone
   (mt/test-driver
@@ -691,3 +691,19 @@
                   (data/run-mbql-query
                    sum_if_test_float
                    {:aggregation [[:sum-where $float_value [:= $discriminator "qaz"]]]}))))))))))
+
+(deftest clickhouse-nippy
+  (mt/test-driver
+   :clickhouse
+   (testing "UnsignedByte"
+     (let [value (com.clickhouse.data.value.UnsignedByte/valueOf "214")]
+       (is (= value (nippy/thaw (nippy/freeze value))))))
+   (testing "UnsignedShort"
+     (let [value (com.clickhouse.data.value.UnsignedShort/valueOf "62055")]
+       (is (= value (nippy/thaw (nippy/freeze value))))))
+   (testing "UnsignedInteger"
+     (let [value (com.clickhouse.data.value.UnsignedInteger/valueOf "4748364")]
+       (is (= value (nippy/thaw (nippy/freeze value))))))
+   (testing "UnsignedLong"
+     (let [value (com.clickhouse.data.value.UnsignedLong/valueOf "84467440737095")]
+       (is (= value (nippy/thaw (nippy/freeze value))))))))

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -21,7 +21,7 @@
                                 :ssl false
                                 :use_no_proxy false
                                 :use_server_time_zone_for_dates true
-                                :product_name "metabase/1.1.4"})
+                                :product_name "metabase/1.1.5"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")


### PR DESCRIPTION
## Summary
Resolves #147 

Four same questions on a dashboard, each cached with [cell towers](https://clickhouse.com/docs/en/getting-started/example-datasets/cell-towers), which has `UnsignedByte`/`UnsignedShort`/`UnsignedInteger` JDBC driver values:

![image](https://github.com/ClickHouse/metabase-clickhouse-driver/assets/3175289/550f39c0-ff4d-44d4-8135-55fb8068cccb)

## Checklist
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
