### PR TITLE
Date bucketing fixes

### DIFF
--- a/.docker/clickhouse/single_node/config.xml
+++ b/.docker/clickhouse/single_node/config.xml
@@ -25,4 +25,11 @@
     <console>1</console>
   </logger>
 
+  <query_log>
+    <database>system</database>
+    <table>query_log</table>
+    <partition_by>toYYYYMM(event_date)</partition_by>
+    <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+  </query_log>
+
 </clickhouse>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.6
+
+### Bug fixes
+
+* Fixed date time bucketing issues (see [#155](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/155))
+
 # 1.1.5
 
 ### Bug fixes

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.1.5
+  version: 1.1.6
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/test/metabase/driver/clickhouse_test_utils.clj
+++ b/test/metabase/driver/clickhouse_test_utils.clj
@@ -89,7 +89,12 @@
                  (str "CREATE TABLE `metabase_test`.`sum_if_test_float`"
                       "(id Int64, float_value Float64, discriminator String) ENGINE = Memory;")
                  (str "INSERT INTO `metabase_test`.`sum_if_test_float` VALUES"
-                      "(1, 1.1, 'foo'), (2, 1.44, 'foo'), (3, 3.5, 'bar'), (4, 5.77, 'bar');")]]
+                      "(1, 1.1, 'foo'), (2, 1.44, 'foo'), (3, 3.5, 'bar'), (4, 5.77, 'bar');")
+                 ;; Temporal bucketing tests
+                 (str "CREATE TABLE `metabase_test`.`temporal_bucketing`"
+                      "(start_of_year DateTime, mid_of_year DateTime, end_of_year DateTime) ENGINE = Memory;")
+                 (str "INSERT INTO `metabase_test`.`temporal_bucketing` VALUES"
+                      "('2022-01-01 00:00:00', '2022-06-20 06:32:54', '2022-12-31 23:59:59');")]]
       (jdbc/execute! conn [sql]))))
 
 (defn do-with-metabase-test-db

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -21,7 +21,7 @@
                                 :ssl false
                                 :use_no_proxy false
                                 :use_server_time_zone_for_dates true
-                                :product_name "metabase/1.1.5"})
+                                :product_name "metabase/1.1.6"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")


### PR DESCRIPTION
## Summary
* Resolves #155 
* Query log is enabled by default for the test ClickHouse instance
* Date bucketing functions refactoring
* Unit tests where reasonably possible (week tests are omitted; there are many such tests in the main Metabase tests with all possible starting days and all of that).

The issue here was mainly in the ResultSet values extraction. After the introduction of the new value wrappers in the JDBC driver, integer types were cast to strings by default, and Metabase UI did not like that. Surprisingly, most of the other stuff was still working as expected.

The charts look better now (my Metabase instance's week starts on Sunday):

![image](https://github.com/ClickHouse/metabase-clickhouse-driver/assets/3175289/dce009d3-1ef9-46da-847d-62d846093e23)
![image](https://github.com/ClickHouse/metabase-clickhouse-driver/assets/3175289/f1a06ae4-017e-4e22-a1cc-9231f6b05243)
![image](https://github.com/ClickHouse/metabase-clickhouse-driver/assets/3175289/5e98c0e8-4d3c-4b39-83fd-1c7774653611)
![image](https://github.com/ClickHouse/metabase-clickhouse-driver/assets/3175289/64f4f44c-e77c-4e66-9f4d-6bec771ed8d4)

NB: "53rd" week resets to the "1st" again, and [it was reported in the main Metabase repo](https://github.com/metabase/metabase/issues/10122). That is odd behavior; I wasn't able to figure out a fix on the driver level.

![image](https://github.com/ClickHouse/metabase-clickhouse-driver/assets/3175289/d6c2e651-1aef-458b-be56-995ebe1b8f75)

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
