### PR TITLE
Use ClickHouse startsWith/endsWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * JDBC driver upgrade (v0.4.1 -> [v0.4.6](https://github.com/ClickHouse/clickhouse-java/releases/tag/v0.4.6))
 * Support DateTime64 by [@lucas-tubi](https://github.com/lucas-tubi) ([#165](https://github.com/ClickHouse/metabase-clickhouse-driver/pull/165))
+* Use native `startsWith`/`endsWith` instead of `LIKE str%`/`LIKE %str`
 
 # 1.1.6
 


### PR DESCRIPTION
## Summary
Use native `startsWith`/`endsWith` instead of `LIKE str%`/`LIKE %str`

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
