### PR TITLE
Switch betwen LIKE and hasToken for :contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.8
+
+### New features
+
+* It is now possible to alter the `:contains` function behavior via driver configuration in Advanced Options. By default, it still uses `LIKE %str%` call (as it was implemented before); however, it can be changed with a toggle to utilize `hasToken(str)` instead. It can be useful for columns where the data is optimized for indices such as `tokenbf_v1`.
+
 # 1.1.7
 
 ### New features

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -36,6 +36,19 @@ driver:
       type: boolean
       visible-if:
         advanced-options: true
+    - name: use-has-token-for-contains
+      display-name: Use hasToken instead of LIKE for :contains calls
+      description: "If you call :contains only on columns with tokenbf_v1 indices,
+        you could try enabling this option to improve the performance.
+        Caution: enabling this option will alter ALL :contains calls
+        which can cause false negatives with certain strings.
+        For example, 'red' is not a token in a string 'Fred',
+        and it will yield a negative result with hasToken,
+        but LIKE %% (default behavior) will work as expected"
+      default: false
+      type: boolean
+      visible-if:
+        advanced-options: true
     - merge:
         - additional-options
         - placeholder: "connection_timeout=1000&max_rows_to_group_by=42"

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -37,14 +37,14 @@ driver:
       visible-if:
         advanced-options: true
     - name: use-has-token-for-contains
-      display-name: Use hasToken instead of LIKE for :contains calls
-      description: "If you call :contains only on columns with tokenbf_v1 indices,
+      display-name: Use hasToken instead of LIKE for "string contains" filters
+      description: "If you use \"string contains\" filters only on columns with tokenbf_v1 indices,
         you could try enabling this option to improve the performance.
-        Caution: enabling this option will alter ALL :contains calls
+        Caution: enabling this option will alter ALL \"string contains\" calls
         which can cause false negatives with certain strings.
         For example, 'red' is not a token in a string 'Fred',
         and it will yield a negative result with hasToken,
-        but LIKE %% (default behavior) will work as expected"
+        but LIKE %% (default behavior) will work as expected."
       default: false
       type: boolean
       visible-if:

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -461,7 +461,7 @@
         (hsql/raw (format "INTERVAL %d %s" (int amount) (name unit)))))
 
 ;; The following lines make sure we call lowerUTF8 instead of lower
-(defn- ch-like-clause
+(defn- clickhouse-like-clause
   [driver field value options]
   (if (get options :case-sensitive true)
     [:like field (sql.qp/->honeysql driver value)]
@@ -484,10 +484,10 @@
   [driver [_ field value options]]
   (if (boolean (get-in (qp.store/database) [:details :use-has-token-for-contains]))
     (clickhouse-string-fn :hasToken field value options)
-    (ch-like-clause driver
-                    (sql.qp/->honeysql driver field)
-                    (update-string-value value #(str \% % \%))
-                    options)))
+    (clickhouse-like-clause driver
+                            (sql.qp/->honeysql driver field)
+                            (update-string-value value #(str \% % \%))
+                            options)))
 
 (defmethod sql.qp/->honeysql [:clickhouse :starts-with]
   [_ [_ field value options]]

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -352,35 +352,35 @@
 
 (deftest clickhouse-datetime64-filter
   (mt/test-driver
-    :clickhouse
-    (let [row1 "2022-03-03 03:03:03.333"
-          row2 "2022-03-03 03:03:03.444"
-          row3 "2022-03-03 03:03:03"
-          query-result (data/dataset
-                         (tx/dataset-definition "metabase_tests_datetime64"
-                                                ["test-data-datetime64"
-                                                 [{:field-name "milli_sec"
-                                                   :base-type {:native "DateTime64(3)"}}]
-                                                 [[row1] [row2] [row3]]])
-                         (data/run-mbql-query test-data-datetime64 {:filter [:= $milli_sec "2022-03-03T03:03:03.333Z"]}))
-          result (ctd/rows-without-index query-result)]
-      (is (= [["2022-03-03T03:03:03.333Z"]] result)))))
+   :clickhouse
+   (let [row1 "2022-03-03 03:03:03.333"
+         row2 "2022-03-03 03:03:03.444"
+         row3 "2022-03-03 03:03:03"
+         query-result (data/dataset
+                       (tx/dataset-definition "metabase_tests_datetime64"
+                                              ["test-data-datetime64"
+                                               [{:field-name "milli_sec"
+                                                 :base-type {:native "DateTime64(3)"}}]
+                                               [[row1] [row2] [row3]]])
+                       (data/run-mbql-query test-data-datetime64 {:filter [:= $milli_sec "2022-03-03T03:03:03.333Z"]}))
+         result (ctd/rows-without-index query-result)]
+     (is (= [["2022-03-03T03:03:03.333Z"]] result)))))
 
 (deftest clickhouse-datetime-filter
   (mt/test-driver
-    :clickhouse
-    (let [row1 "2022-03-03 03:03:03"
-          row2 "2022-03-03 03:03:04"
-          row3 "2022-03-03 03:03:05"
-          query-result (data/dataset
-                         (tx/dataset-definition "metabase_tests_datetime"
-                                                ["test-data-datetime"
-                                                 [{:field-name "second"
-                                                   :base-type {:native "DateTime"}}]
-                                                 [[row1] [row2] [row3]]])
-                         (data/run-mbql-query test-data-datetime {:filter [:= $second "2022-03-03T03:03:04Z"]}))
-          result (ctd/rows-without-index query-result)]
-      (is (= [["2022-03-03T03:03:04Z"]] result)))))
+   :clickhouse
+   (let [row1 "2022-03-03 03:03:03"
+         row2 "2022-03-03 03:03:04"
+         row3 "2022-03-03 03:03:05"
+         query-result (data/dataset
+                       (tx/dataset-definition "metabase_tests_datetime"
+                                              ["test-data-datetime"
+                                               [{:field-name "second"
+                                                 :base-type {:native "DateTime"}}]
+                                               [[row1] [row2] [row3]]])
+                       (data/run-mbql-query test-data-datetime {:filter [:= $second "2022-03-03T03:03:04Z"]}))
+         result (ctd/rows-without-index query-result)]
+     (is (= [["2022-03-03T03:03:04Z"]] result)))))
 
 (deftest clickhouse-booleans
   (mt/test-driver
@@ -819,3 +819,26 @@
               (temporal-bucketing-query-mid-year-field :quarter-of-year)))
        (is (= [[4]]
               (temporal-bucketing-query-end-of-year-field :quarter-of-year)))))))
+
+(deftest clickhouse-use-has-token-for-contains-setting
+  (mt/test-driver
+   :clickhouse
+   (defn query [details]
+     (qp.test/formatted-rows
+      [str]
+      (ctd/do-with-metabase-test-db
+       (fn [db]
+         (data/with-db db
+           (data/run-mbql-query
+            use_has_token_for_contains_test
+            {:filter [:contains %str "red"]})))
+       details)))
+   (testing "is not set"
+     (is (= [["Fred"] ["red"]]
+            (query nil))))
+   (testing "explicit true"
+     (is (= [["red"]]
+            (query {:use-has-token-for-contains true}))))
+   (testing "explicit false"
+     (is (= [["Fred"] ["red"]]
+            (query {:use-has-token-for-contains false}))))))

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -823,7 +823,7 @@
 (deftest clickhouse-use-has-token-for-contains-setting
   (mt/test-driver
    :clickhouse
-   (defn query [details]
+   (defn query [case-sensitive details]
      (qp.test/formatted-rows
       [str]
       (ctd/do-with-metabase-test-db
@@ -831,14 +831,20 @@
          (data/with-db db
            (data/run-mbql-query
             use_has_token_for_contains_test
-            {:filter [:contains %str "red"]})))
+            {:filter [:contains %str "red" {:case-sensitive case-sensitive}]})))
        details)))
    (testing "is not set"
      (is (= [["Fred"] ["red"]]
-            (query nil))))
+            (query true nil)))
+     (is (= [["Fred"] ["FRED"] ["red"] ["Red"]]
+            (query false nil))))
    (testing "explicit true"
      (is (= [["red"]]
-            (query {:use-has-token-for-contains true}))))
+            (query true {:use-has-token-for-contains true})))
+     (is (= [["red"] ["Red"]]
+            (query false {:use-has-token-for-contains true}))))
    (testing "explicit false"
      (is (= [["Fred"] ["red"]]
-            (query {:use-has-token-for-contains false}))))))
+            (query true {:use-has-token-for-contains false})))
+     (is (= [["Fred"] ["FRED"] ["red"] ["Red"]]
+            (query false {:use-has-token-for-contains false}))))))

--- a/test/metabase/test/data/datasets.sql
+++ b/test/metabase/test/data/datasets.sql
@@ -127,4 +127,4 @@ CREATE TABLE `metabase_test`.`use_has_token_for_contains_test`
 (str String) ENGINE = Memory;
 
 INSERT INTO `metabase_test`.`use_has_token_for_contains_test`
-VALUES ('Fred'), ('red');
+VALUES ('Fred'), ('FRED'), ('red'), ('Red');

--- a/test/metabase/test/data/datasets.sql
+++ b/test/metabase/test/data/datasets.sql
@@ -121,3 +121,10 @@ CREATE DATABASE `metabase_db_scan_test`;
 
 CREATE TABLE `metabase_db_scan_test`.`table1` (i Int32) ENGINE = Memory;
 CREATE TABLE `metabase_db_scan_test`.`table2` (i Int64) ENGINE = Memory;
+
+-- use-has-token-for-contains setting (LIKE %% vs hasToken) test
+CREATE TABLE `metabase_test`.`use_has_token_for_contains_test`
+(str String) ENGINE = Memory;
+
+INSERT INTO `metabase_test`.`use_has_token_for_contains_test`
+VALUES ('Fred'), ('red');


### PR DESCRIPTION
## Summary
Resolves #173
Adds an option to switch between `LIKE %str%` (default behavior) and `hasToken` via an advanced UI setting (the description does not look very good, but I couldn't do anything about it).

![image](https://github.com/ClickHouse/metabase-clickhouse-driver/assets/3175289/d2f3a620-6ae5-4a7d-b345-1b765650dca4)

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
