### PR TITLE
Metabase 0.47 support, reworked base types mapping

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.47.0-RC1
+          # The latest commit on release-0.47.x branch - fixed failing MB tests
+          ref: dba05c0b6f6cbc6e2f8247c03cc5fcc986cd3fe5
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.46.5
-
+          ref: v0.47.0-RC1
+          
       - name: Checkout Driver Repo
         uses: actions/checkout@v2
         with:
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
           cache: "yarn"
 
       - name: Get M2 cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.47.0-RC2
+          ref: v0.47.0-RC1
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.47.0-RC1
-          
+          ref: v0.47.0-RC2
+
       - name: Checkout Driver Repo
         uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.2.0
+
+### New features
+* Metabase 0.47 support
+* Connection impersonation support (0.47 feature)
+
+### Bug fixes
+* `DateTime64` is now correctly mapped to `:type/DateTime`
+
 # 1.1.7
 
 ### New features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     hostname: server.clickhouseconnect.test
 
   metabase:
-    image: metabase/metabase:v0.46.5
+    image: metabase/metabase:v0.47.0-RC1
     container_name: metabase-with-clickhouse-driver
     environment:
       'MB_HTTP_TIMEOUT': '5000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     hostname: server.clickhouseconnect.test
 
   metabase:
-    image: metabase/metabase:v0.47.0-RC1
+    image: metabase/metabase:v0.47.0-RC2
     container_name: metabase-with-clickhouse-driver
     environment:
       'MB_HTTP_TIMEOUT': '5000'

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.1.7
+  version: 1.2.0
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -593,4 +593,4 @@
 (defmethod driver/db-start-of-week :clickhouse [_] :monday)
 
 (defmethod ddl.i/format-name :clickhouse [_ table-or-field-name]
-  (u/snake-key table-or-field-name))
+  (u/->snake_case_en table-or-field-name))

--- a/test/metabase/driver/clickhouse_base_types_test.clj
+++ b/test/metabase/driver/clickhouse_base_types_test.clj
@@ -1,0 +1,282 @@
+(ns metabase.driver.clickhouse-test
+  #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.test :as mt]
+   [metabase.test.data.clickhouse :as ctd]))
+
+(def ^:private describe-keys [:name :database-type :base-type :database-required])
+(defn- desc-table
+  [table-name]
+  (into #{} (map #(select-keys % describe-keys)
+                 (:fields (ctd/do-with-metabase-test-db
+                           #(driver/describe-table :clickhouse % {:name table-name}))))))
+
+(deftest clickhouse-base-types-test
+  (mt/test-driver
+   :clickhouse
+   (testing "enums"
+     (let [table-name "enums_base_types"]
+       (is (= #{{:base-type :type/Text,
+                 :database-required false,
+                 :database-type "Nullable(Enum8('America/New_York' = 1))",
+                 :name "c1"}
+                {:base-type :type/Text,
+                 :database-required true,
+                 :database-type "Enum8('BASE TABLE' = 1, 'VIEW' = 2, 'FOREIGN TABLE' = 3, 'LOCAL TEMPORARY' = 4, 'SYSTEM VIEW' = 5)",
+                 :name "c2"}
+                {:base-type :type/Text,
+                 :database-required true,
+                 :database-type "Enum8('NO' = 1, 'YES' = 2)",
+                 :name "c3"}
+                {:base-type :type/Text,
+                 :database-required true,
+                 :database-type "Enum16('SHOW DATABASES' = 0, 'SHOW TABLES' = 1, 'SHOW COLUMNS' = 2)",
+                 :name "c4"}
+                {:base-type :type/Text,
+                 :database-required false,
+                 :database-type "Nullable(Enum8('GLOBAL' = 0, 'DATABASE' = 1, 'TABLE' = 2))",
+                 :name "c5"}
+                {:base-type :type/Text,
+                 :database-required false,
+                 :database-type "Nullable(Enum16('SHOW DATABASES' = 0, 'SHOW TABLES' = 1, 'SHOW COLUMNS' = 2))",
+                 :name "c6"}}
+              (desc-table table-name)))))
+   (testing "dates"
+     (let [table-name "date_base_types"]
+       (is (= #{{:base-type :type/Date,
+                 :database-required true,
+                 :database-type "Date",
+                 :name "c1"}
+                {:base-type :type/Date,
+                 :database-required true,
+                 :database-type "Date32",
+                 :name "c2"}
+                {:base-type :type/Date,
+                 :database-required false,
+                 :database-type "Nullable(Date)",
+                 :name "c3"}
+                {:base-type :type/Date,
+                 :database-required false,
+                 :database-type "Nullable(Date32)",
+                 :name "c4"}}
+              (desc-table table-name)))))
+   (testing "datetimes"
+     (let [table-name "datetime_base_types"]
+       (is (= #{{:base-type :type/DateTime,
+                 :database-required false,
+                 :database-type "Nullable(DateTime('America/New_York'))",
+                 :name "c1"}
+                {:base-type :type/DateTime,
+                 :database-required true,
+                 :database-type "DateTime('America/New_York')",
+                 :name "c2"}
+                {:base-type :type/DateTime,
+                 :database-required true,
+                 :database-type "DateTime",
+                 :name "c3"}
+                {:base-type :type/DateTime,
+                 :database-required true,
+                 :database-type "DateTime64(3)",
+                 :name "c4"}
+                {:base-type :type/DateTime,
+                 :database-required true,
+                 :database-type "DateTime64(9, 'America/New_York')",
+                 :name "c5"}
+                {:base-type :type/DateTime,
+                 :database-required false,
+                 :database-type "Nullable(DateTime64(6, 'America/New_York'))",
+                 :name "c6"}
+                {:base-type :type/DateTime,
+                 :database-required false,
+                 :database-type "Nullable(DateTime64(0))",
+                 :name "c7"}
+                {:base-type :type/DateTime,
+                 :database-required false,
+                 :database-type "Nullable(DateTime)",
+                 :name "c8"}}
+              (desc-table table-name)))))
+   (testing "integers"
+     (let [table-name "integer_base_types"]
+       (is (= #{{:base-type :type/Integer,
+                 :database-required true,
+                 :database-type "UInt8",
+                 :name "c1"}
+                {:base-type :type/Integer,
+                 :database-required true,
+                 :database-type "UInt16",
+                 :name "c2"}
+                {:base-type :type/Integer,
+                 :database-required true,
+                 :database-type "UInt32",
+                 :name "c3"}
+                {:base-type :type/BigInteger,
+                 :database-required true,
+                 :database-type "UInt64",
+                 :name "c4"}
+                {:base-type :type/*,
+                 :database-required true,
+                 :database-type "UInt128",
+                 :name "c5"}
+                {:base-type :type/*,
+                 :database-required true,
+                 :database-type "UInt256",
+                 :name "c6"}
+                {:base-type :type/Integer,
+                 :database-required true,
+                 :database-type "Int8",
+                 :name "c7"}
+                {:base-type :type/Integer,
+                 :database-required true,
+                 :database-type "Int16",
+                 :name "c8"}
+                {:base-type :type/Integer,
+                 :database-required true,
+                 :database-type "Int32",
+                 :name "c9"}
+                {:base-type :type/BigInteger,
+                 :database-required true,
+                 :database-type "Int64",
+                 :name "c10"}
+                {:base-type :type/*,
+                 :database-required true,
+                 :database-type "Int128",
+                 :name "c11"}
+                {:base-type :type/*,
+                 :database-required true,
+                 :database-type "Int256",
+                 :name "c12"}
+                {:base-type :type/Integer,
+                 :database-required false,
+                 :database-type "Nullable(Int32)",
+                 :name "c13"}}
+              (desc-table table-name)))))
+   (testing "numerics"
+     (let [table-name "numeric_base_types"]
+       (is (= #{{:base-type :type/Float,
+                 :database-required true,
+                 :database-type "Float32",
+                 :name "c1"}
+                {:base-type :type/Float,
+                 :database-required true,
+                 :database-type "Float64",
+                 :name "c2"}
+                {:base-type :type/Decimal,
+                 :database-required true,
+                 :database-type "Decimal(4, 2)",
+                 :name "c3"}
+                {:base-type :type/Decimal,
+                 :database-required true,
+                 :database-type "Decimal(9, 7)",
+                 :name "c4"}
+                {:base-type :type/Decimal,
+                 :database-required true,
+                 :database-type "Decimal(18, 12)",
+                 :name "c5"}
+                {:base-type :type/Decimal,
+                 :database-required true,
+                 :database-type "Decimal(38, 24)",
+                 :name "c6"}
+                {:base-type :type/Decimal,
+                 :database-required true,
+                 :database-type "Decimal(76, 42)",
+                 :name "c7"}
+                {:base-type :type/Float,
+                 :database-required false,
+                 :database-type "Nullable(Float32)",
+                 :name "c8"}
+                {:base-type :type/Decimal,
+                 :database-required false,
+                 :database-type "Nullable(Decimal(4, 2))",
+                 :name "c9"}
+                {:base-type :type/Decimal,
+                 :database-required false,
+                 :database-type "Nullable(Decimal(76, 42))",
+                 :name "c10"}}
+              (desc-table table-name)))))
+   (testing "strings"
+     (let [table-name "string_base_types"]
+       (is (= #{{:base-type :type/Text,
+                 :database-required true,
+                 :database-type "String",
+                 :name "c1"}
+                {:base-type :type/Text,
+                 :database-required true,
+                 :database-type "LowCardinality(String)",
+                 :name "c2"}
+                {:base-type :type/TextLike,
+                 :database-required true,
+                 :database-type "FixedString(32)",
+                 :name "c3"}
+                {:base-type :type/Text,
+                 :database-required false,
+                 :database-type "Nullable(String)",
+                 :name "c4"}
+                {:base-type :type/TextLike,
+                 :database-required true,
+                 :database-type "LowCardinality(FixedString(4))",
+                 :name "c5"}}
+              (desc-table table-name)))))
+   (testing "arrays"
+     (let [table-name "array_base_types"]
+       (is (= #{{:base-type :type/Array,
+                 :database-required true,
+                 :database-type "Array(String)",
+                 :name "c1"}
+                {:base-type :type/Array,
+                 :database-required true,
+                 :database-type "Array(Nullable(Int32))",
+                 :name "c2"}
+                {:base-type :type/Array,
+                 :database-required true,
+                 :database-type "Array(Array(LowCardinality(FixedString(32))))",
+                 :name "c3"}
+                {:base-type :type/Array,
+                 :database-required true,
+                 :database-type "Array(Array(Array(String)))",
+                 :name "c4"}}
+              (desc-table table-name)))))
+   (testing "everything else"
+     (let [table-name "misc_base_types"]
+       (is (= #{{:base-type :type/Boolean,
+                 :database-required true,
+                 :database-type "Bool",
+                 :name "c1"}
+                {:base-type :type/UUID,
+                 :database-required true,
+                 :database-type "UUID",
+                 :name "c2"}
+                {:base-type :type/IPAddress,
+                 :database-required true,
+                 :database-type "IPv4",
+                 :name "c3"}
+                {:base-type :type/IPAddress,
+                 :database-required true,
+                 :database-type "IPv6",
+                 :name "c4"}
+                {:base-type :type/Dictionary,
+                 :database-required true,
+                 :database-type "Map(Int32, String)",
+                 :name "c5"}
+                {:base-type :type/Boolean,
+                 :database-required false,
+                 :database-type "Nullable(Bool)",
+                 :name "c6"}
+                {:base-type :type/UUID,
+                 :database-required false,
+                 :database-type "Nullable(UUID)",
+                 :name "c7"}
+                {:base-type :type/IPAddress,
+                 :database-required false,
+                 :database-type "Nullable(IPv4)",
+                 :name "c8"}
+                {:base-type :type/IPAddress,
+                 :database-required false,
+                 :database-type "Nullable(IPv6)",
+                 :name "c9"}
+                {:base-type :type/*,
+                 :database-required true,
+                 :database-type "Tuple(String, Int32)",
+                 :name "c10"}}
+              (desc-table table-name)))))))

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -17,7 +17,7 @@
    [metabase.test.data.sql-jdbc
     [execute :as execute]
     [load-data :as load-data]]
-   [toucan.util.test :as tt]))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (sql-jdbc.tx/add-test-extensions! :clickhouse)
 
@@ -89,7 +89,7 @@
                                 :ssl false
                                 :use_no_proxy false
                                 :use_server_time_zone_for_dates true
-                                :product_name "metabase/1.1.7"})
+                                :product_name "metabase/1.2.0"})
 
 (defn rows-without-index
   "Remove the Metabase index which is the first column in the result set"
@@ -120,7 +120,7 @@
   {:style/indent 0}
   [f]
   (when (not @db-initialized?) (create-metabase-test-db!))
-  (tt/with-temp Database
-    [database (metabase-test-db-details)]
+  (t2.with-temp/with-temp
+    [Database database (metabase-test-db-details)]
     (sync-metadata/sync-db-metadata! database)
     (f database)))

--- a/test/metabase/test/data/datasets.sql
+++ b/test/metabase/test/data/datasets.sql
@@ -121,3 +121,86 @@ CREATE DATABASE `metabase_db_scan_test`;
 
 CREATE TABLE `metabase_db_scan_test`.`table1` (i Int32) ENGINE = Memory;
 CREATE TABLE `metabase_db_scan_test`.`table2` (i Int64) ENGINE = Memory;
+
+-- SET ROLE tests
+CREATE ROLE IF NOT EXISTS `metabase_test_role`;
+CREATE USER IF NOT EXISTS `metabase_test_user` NOT IDENTIFIED;
+GRANT `metabase_test_role` TO `metabase_test_user`;
+
+-- Base type matching tests
+CREATE TABLE `metabase_test`.`enums_base_types` (
+    c1 Nullable(Enum8('America/New_York')),
+    c2 Enum8('BASE TABLE' = 1, 'VIEW' = 2, 'FOREIGN TABLE' = 3, 'LOCAL TEMPORARY' = 4, 'SYSTEM VIEW' = 5),
+    c3 Enum8('NO', 'YES'),
+    c4 Enum16('SHOW DATABASES' = 0, 'SHOW TABLES' = 1, 'SHOW COLUMNS' = 2),
+    c5 Nullable(Enum8('GLOBAL' = 0, 'DATABASE' = 1, 'TABLE' = 2)),
+    c6 Nullable(Enum16('SHOW DATABASES' = 0, 'SHOW TABLES' = 1, 'SHOW COLUMNS' = 2))
+) ENGINE Memory;
+CREATE TABLE `metabase_test`.`date_base_types` (
+    c1 Date,
+    c2 Date32,
+    c3 Nullable(Date),
+    c4 Nullable(Date32)
+) ENGINE Memory;
+CREATE TABLE `metabase_test`.`datetime_base_types` (
+    c1 Nullable(DateTime('America/New_York')),
+    c2 DateTime('America/New_York'),
+    c3 DateTime,
+    c4 DateTime64(3),
+    c5 DateTime64(9, 'America/New_York'),
+    c6 Nullable(DateTime64(6, 'America/New_York')),
+    c7 Nullable(DateTime64(0)),
+    c8 Nullable(DateTime)
+) ENGINE Memory;
+CREATE TABLE `metabase_test`.`integer_base_types` (
+    c1  UInt8,
+    c2  UInt16,
+    c3  UInt32,
+    c4  UInt64,
+    c5  UInt128,
+    c6  UInt256,
+    c7  Int8,
+    c8  Int16,
+    c9  Int32,
+    c10 Int64,
+    c11 Int128,
+    c12 Int256,
+    c13 Nullable(Int32)
+) ENGINE Memory;
+CREATE TABLE `metabase_test`.`numeric_base_types` (
+    c1  Float32,
+    c2  Float64,
+    c3  Decimal(4, 2),
+    c4  Decimal32(7),
+    c5  Decimal64(12),
+    c6  Decimal128(24),
+    c7  Decimal256(42),
+    c8  Nullable(Float32),
+    c9  Nullable(Decimal(4, 2)),
+    c10 Nullable(Decimal256(42))
+) ENGINE Memory;
+CREATE TABLE `metabase_test`.`string_base_types` (
+    c1 String,
+    c2 LowCardinality(String),
+    c3 FixedString(32),
+    c4 Nullable(String),
+    c5 LowCardinality(FixedString(4))
+) ENGINE Memory;
+CREATE TABLE `metabase_test`.`misc_base_types` (
+    c1  Boolean,
+    c2  UUID,
+    c3  IPv4,
+    c4  IPv6,
+    c5  Map(Int32, String),
+    c6  Nullable(Boolean),
+    c7  Nullable(UUID),
+    c8  Nullable(IPv4),
+    c9  Nullable(IPv6),
+    c10 Tuple(String, Int32)
+) ENGINE Memory;
+CREATE TABLE `metabase_test`.`array_base_types` (
+    c1 Array(String),
+    c2 Array(Nullable(Int32)),
+    c3 Array(Array(LowCardinality(FixedString(32)))),
+    c4 Array(Array(Array(String)))
+) ENGINE Memory;


### PR DESCRIPTION
## Summary
* Metabase 0.47 support
* Connection impersonation support (0.47 feature)
* `DateTime64` is now correctly mapped to `:type/DateTime`
* General database type -> base type mapping rework (some test scenarios were taken from https://regex101.com/r/Yahlbt/1, props to @mlosnikov)

Resolves #177 
Resolves #178 
Resolves #179 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

