### PR TITLE
Support Metabase 0.48.x, fix last/next minutes/hours filters with variables, fix SQL formatting in the UI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          # The latest commit on release-0.47.x branch - fixed failing MB tests
-          ref: dba05c0b6f6cbc6e2f8247c03cc5fcc986cd3fe5
+          # Pre-0.48.x master branch
+          ref: e8dc6bff409d53e386c54a71dceb7a4a29b2d140
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout Metabase Repo
         uses: actions/checkout@v2
         with:
-          repository: metabase/metabase
-          # Pre-0.48.x master branch
-          ref: e8dc6bff409d53e386c54a71dceb7a4a29b2d140
+          # FIXME: when https://github.com/metabase/metabase/pull/34873 is merged
+          repository: slvrtrn/metabase
+          ref: 2310e3be0781e92a1469d136df5f54e016cdb0ec
 
       - name: Checkout Driver Repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.3.0
+
+### New features
+* Metabase 0.48.x support
+
+### Bug fixes
+* Fixed last/next minutes/hours filters with variables creating incorrect queries due to unnecessary `CAST col AS date` call.
+* Fixed UI question -> SQL conversion creating incorrect queries due to superfluous spaces in columns/tables/database names.
+
 # 1.2.2
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ docker run -d -p 3000:3000 \
 | 0.45.x           | 1.1.0          |
 | 0.46.x           | 1.1.7          |
 | 0.47.x           | 1.2.2          |
+| 0.48.x           | 1.3.0          |
 
 ## Creating a Metabase Docker image with ClickHouse driver
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     container_name: metabase-with-clickhouse-driver
     environment:
       'MB_HTTP_TIMEOUT': '5000'
+      'JAVA_TIMEZONE': 'UTC'
     ports:
       - '3000:3000'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
     container_name: metabase-with-clickhouse-driver
     environment:
       'MB_HTTP_TIMEOUT': '5000'
-      'JAVA_TIMEZONE': 'UTC'
     ports:
       - '3000:3000'
     volumes:

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.2.2
+  version: 1.3.0
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -2,16 +2,17 @@
   "Driver for ClickHouse databases"
   #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
   (:require [clojure.string :as str]
+            [metabase [config :as config]]
+            [metabase.driver :as driver]
             [metabase.driver.clickhouse-introspection]
             [metabase.driver.clickhouse-nippy]
             [metabase.driver.clickhouse-qp]
             [metabase.driver.ddl.interface :as ddl.i]
             [metabase.driver.sql :as driver.sql]
-            [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc [common :as sql-jdbc.common]
              [connection :as sql-jdbc.conn]]
-            [metabase [config :as config]]
-            [metabase.driver :as driver]))
+            [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+            [metabase.driver.sql.util :as sql.u]))
 
 (set! *warn-on-reflection* true)
 
@@ -19,6 +20,9 @@
 
 (defmethod driver/display-name :clickhouse [_] "ClickHouse")
 (def ^:private product-name "metabase/1.3.0")
+
+(defmethod driver/prettify-native-form :clickhouse [_ native-form]
+  (sql.u/format-sql-and-fix-params :mysql native-form))
 
 (doseq [[feature supported?]
         {:standard-deviation-aggregations true

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -1,34 +1,35 @@
 (ns metabase.driver.clickhouse
   "Driver for ClickHouse databases"
-  (:require [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
-            [metabase.driver :as driver]
+  #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
+  (:require [clojure.string :as str]
             [metabase.driver.clickhouse-introspection]
             [metabase.driver.clickhouse-nippy]
             [metabase.driver.clickhouse-qp]
             [metabase.driver.ddl.interface :as ddl.i]
             [metabase.driver.sql :as driver.sql]
+            [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
             [metabase.driver.sql-jdbc [common :as sql-jdbc.common]
-             [connection :as sql-jdbc.conn]
-             [sync :as sql-jdbc.sync]]
-            [metabase [config :as config]]))
+             [connection :as sql-jdbc.conn]]
+            [metabase [config :as config]]
+            [metabase.driver :as driver]))
 
 (set! *warn-on-reflection* true)
 
 (driver/register! :clickhouse :parent :sql-jdbc)
 
 (defmethod driver/display-name :clickhouse [_] "ClickHouse")
-(def ^:private product-name "metabase/1.2.2")
+(def ^:private product-name "metabase/1.3.0")
 
-(doseq [[feature supported?] {:standard-deviation-aggregations true
-                              :foreign-keys                    (not config/is-test?)
-                              :set-timezone                    false
-                              :convert-timezone                false
-                              :test/jvm-timezone-setting       false
-                              :connection-impersonation        false
-                              :schemas                         true}]
-
-  (defmethod driver/database-supports? [:clickhouse feature] [_driver _feature _db] supported?))
+(doseq [[feature supported?]
+        {:standard-deviation-aggregations true
+         :foreign-keys                    (not config/is-test?)
+         :set-timezone                    false
+         :convert-timezone                false
+         :test/jvm-timezone-setting       false
+         :connection-impersonation        false
+         :schemas                         true}]
+  (defmethod driver/database-supports? [:clickhouse feature]
+    [_driver _feature _db] supported?))
 
 (def ^:private default-connection-details
   {:user "default" :password "" :dbname "default" :host "localhost" :port "8123"})
@@ -52,11 +53,15 @@
       :product_name product-name}
      (sql-jdbc.common/handle-additional-options details :separator-style :url))))
 
-(defmethod sql-jdbc.sync/db-default-timezone :clickhouse
-  [_ spec]
-  (let [sql (str "SELECT timezone() AS tz")
-        [{:keys [tz]}] (jdbc/query spec sql)]
-    tz))
+(defmethod driver/db-default-timezone :clickhouse
+  [driver database]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver database nil
+   (fn [^java.sql.Connection conn]
+     (with-open [stmt (.prepareStatement conn "SELECT timezone() AS tz")
+                 rset (.executeQuery stmt)]
+       (when (.next rset)
+         (.getString rset 1))))))
 
 (defmethod driver/db-start-of-week :clickhouse [_] :monday)
 

--- a/src/metabase/driver/clickhouse_introspection.clj
+++ b/src/metabase/driver/clickhouse_introspection.clj
@@ -28,9 +28,8 @@
     [#"Int16" :type/Integer]
     [#"Int32" :type/Integer]
     [#"Int64" :type/BigInteger]
-    ;; FIXME: set it back to IPAddress when 0.48 is out, as it should resolve IPAddress and other semantic types checks issues
-    [#"IPv4" :type/TextLike]
-    [#"IPv6" :type/TextLike]
+    [#"IPv4" :type/IPAddress]
+    [#"IPv6" :type/IPAddress]
     [#"Map" :type/Dictionary]
     [#"String" :type/Text]
     [#"Tuple" :type/*]
@@ -141,14 +140,14 @@
 
 (defn- ^:private is-db-required?
   [field]
-  (not (str/starts-with? (get-in field [:database-type]) "Nullable")))
+  (not (str/starts-with? (get field :database-type) "Nullable")))
 
 (defmethod driver/describe-table :clickhouse
   [_ database table]
   (let [table-metadata (sql-jdbc.sync/describe-table :clickhouse database table)
         filtered-fields (for [field (:fields table-metadata)
-                              :let [updated-field (update-in field [:database-required]
-                                                             (fn [_] (is-db-required? field)))]
+                              :let [updated-field (update field :database-required
+                                                          (fn [_] (is-db-required? field)))]
                               ;; Skip all AggregateFunction (but keeping SimpleAggregateFunction) columns
                               ;; JDBC does not support that and it crashes the data browser
                               :when (not (re-matches #"^AggregateFunction\(.+$"

--- a/test/metabase/driver/clickhouse_base_types_test.clj
+++ b/test/metabase/driver/clickhouse_base_types_test.clj
@@ -246,11 +246,11 @@
                  :database-required true,
                  :database-type "UUID",
                  :name "c2"}
-                {:base-type :type/TextLike,
+                {:base-type :type/IPAddress,
                  :database-required true,
                  :database-type "IPv4",
                  :name "c3"}
-                {:base-type :type/TextLike,
+                {:base-type :type/IPAddress,
                  :database-required true,
                  :database-type "IPv6",
                  :name "c4"}
@@ -266,11 +266,11 @@
                  :database-required false,
                  :database-type "Nullable(UUID)",
                  :name "c7"}
-                {:base-type :type/TextLike,
+                {:base-type :type/IPAddress,
                  :database-required false,
                  :database-type "Nullable(IPv4)",
                  :name "c8"}
-                {:base-type :type/TextLike,
+                {:base-type :type/IPAddress,
                  :database-required false,
                  :database-type "Nullable(IPv6)",
                  :name "c9"}

--- a/test/metabase/driver/clickhouse_substitution_test.clj
+++ b/test/metabase/driver/clickhouse_substitution_test.clj
@@ -1,0 +1,227 @@
+(ns metabase.driver.clickhouse-test
+  #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
+  (:require [clojure.test :refer :all]
+            [java-time.api :as t]
+            [metabase.driver.clickhouse-base-types-test]
+            [metabase.driver.clickhouse-temporal-bucketing-test]
+            [metabase.query-processor :as qp]
+            [metabase.test :as mt]
+            [metabase.test.data :as data]
+            [metabase.test.data [interface :as tx]]
+            [metabase.test.data.clickhouse :as ctd]
+            [metabase.util :as u]
+            [schema.core :as s])
+  (:import (java.time LocalDate LocalDateTime)))
+
+(set! *warn-on-reflection* true)
+
+(defn- get-mbql
+  [value db]
+  (let [uuid (str (java.util.UUID/randomUUID))]
+    {:database (mt/id)
+     :type "native"
+     :native {:collection "test-table"
+              :template-tags
+              {:x {:id uuid
+                   :name "d"
+                   :display-name "D"
+                   :type "dimension"
+                   :dimension ["field" (mt/id :test-table :d) nil]
+                   :required true}}
+              :query (format "SELECT * FROM `%s`.`test_table` WHERE {{x}}" db)}
+     :parameters [{:type "date/all-options"
+                   :value value
+                   :target ["dimension" ["template-tag" "x"]]
+                   :id uuid}]}))
+
+(def ^:private clock (t/mock-clock (t/instant "2019-11-30T23:00:00Z") (t/zone-id "UTC")))
+(s/defn ^:private local-date-now      :- LocalDate     [] (LocalDate/now clock))
+(s/defn ^:private local-date-time-now :- LocalDateTime [] (LocalDateTime/now clock))
+
+(deftest clickhouse-variables-field-filters-datetime-and-datetime64
+  (mt/test-driver
+   :clickhouse
+   (mt/with-clock clock
+     (letfn
+      [(->clickhouse-input
+         [^LocalDateTime ldt]
+         [(t/format "yyyy-MM-dd HH:mm:ss" ldt)])
+       (get-test-table
+         [rows native-type]
+         ["test_table"
+          [{:field-name "d"
+            :base-type {:native native-type}}]
+          (map ->clickhouse-input rows)])
+       (->iso-str
+         [^LocalDateTime ldt]
+         (t/format "yyyy-MM-dd'T'HH:mm:ss'Z'" ldt))]
+       (doseq [base-type ["DateTime" "DateTime64"]]
+         (testing base-type
+           (testing "past/next minutes"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_minutes_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-time-now)
+                   row1  (.minusHours   now 14)
+                   row2  (.minusMinutes now 20)
+                   row3  (.plusMinutes  now 5)
+                   row4  (.plusHours    now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past30minutes"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past30minutes" db))))))
+                (testing "next30minutes"
+                  (is (= [[(->iso-str row3)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next30minutes" db)))))))))
+           (testing "past/next hours"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_hours_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-time-now)
+                   row1  (.minusHours now 14)
+                   row2  (.minusHours now 2)
+                   row3  (.plusHours  now 25)
+                   row4  (.plusHours  now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past12hours"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past12hours" db))))))
+                (testing "next12hours"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next12hours" db)))))))))
+           (testing "past/next days"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_days_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-time-now)
+                   row1  (.minusDays now 14)
+                   row2  (.minusDays now 2)
+                   row3  (.plusDays  now 25)
+                   row4  (.plusDays  now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past12days"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past12days" db))))))
+                (testing "next12days"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next12days" db)))))))))
+           (testing "past/next months/quarters"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_months_quarters_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-time-now)
+                   row1  (.minusMonths now 14)
+                   row2  (.minusMonths now 4)
+                   row3  (.plusMonths  now 25)
+                   row4  (.plusMonths  now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past12months"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past12months" db))))))
+                (testing "next12months"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next12months" db))))))
+                (testing "past3quarters"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past3quarters" db))))))
+                (testing "next3quarters"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next3quarters" db)))))))))
+           (testing "past/next years"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_years_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-time-now)
+                   row1  (.minusYears now 14)
+                   row2  (.minusYears now 4)
+                   row3  (.plusYears  now 25)
+                   row4  (.plusYears  now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past12years"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past12years" db))))))
+                (testing "next12years"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next12years" db)))))))))))))))
+
+(deftest clickhouse-variables-field-filters-date-and-date32
+  (mt/test-driver
+   :clickhouse
+   (mt/with-clock clock
+     (letfn
+      [(->clickhouse-input
+         [^LocalDate ld]
+         [(t/format "yyyy-MM-dd" ld)])
+       (get-test-table
+         [rows native-type]
+         ["test_table"
+          [{:field-name "d"
+            :base-type {:native native-type}}]
+          (map ->clickhouse-input rows)])
+       (->iso-str
+         [^LocalDate ld]
+         (str (t/format "yyyy-MM-dd" ld) "T00:00:00Z"))]
+       (doseq [base-type ["Date" "Date32"]]
+         (testing base-type
+           (testing "past/next days"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_days_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-now)
+                   row1  (.minusDays now 14)
+                   row2  (.minusDays now 2)
+                   row3  (.plusDays  now 25)
+                   row4  (.plusDays  now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past12days"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past12days" db))))))
+                (testing "next12days"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next12days" db)))))))))
+           (testing "past/next months/quarters"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_months_quarters_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-now)
+                   row1  (.minusMonths now 14)
+                   row2  (.minusMonths now 4)
+                   row3  (.plusMonths  now 25)
+                   row4  (.plusMonths  now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past12months"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past12months" db))))))
+                (testing "next12months"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next12months" db))))))
+                (testing "past3quarters"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past3quarters" db))))))
+                (testing "next3quarters"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next3quarters" db)))))))))
+           (testing "past/next years"
+             (let [db    (format "metabase_tests_variables_replacement_past_next_years_%s"
+                                 (u/lower-case-en base-type))
+                   now   (local-date-now)
+                   row1  (.minusYears now 14)
+                   row2  (.minusYears now 4)
+                   row3  (.plusYears  now 25)
+                   row4  (.plusYears  now 6)
+                   table (get-test-table [row1 row2 row3 row4] base-type)]
+               (data/dataset
+                (tx/dataset-definition db table)
+                (testing "past12years"
+                  (is (= [[(->iso-str row2)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "past12years" db))))))
+                (testing "next12years"
+                  (is (= [[(->iso-str row4)]]
+                         (ctd/rows-without-index (qp/process-query (get-mbql "next12years" db)))))))))))))))

--- a/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
+++ b/test/metabase/driver/clickhouse_temporal_bucketing_test.clj
@@ -2,7 +2,7 @@
   #_{:clj-kondo/ignore [:unsorted-required-namespaces]}
   (:require
    [clojure.test :refer :all]
-   [metabase.query-processor-test :as qp.test]
+   [metabase.query-processor.test-util :as qp.test]
    [metabase.test :as mt]
    [metabase.test.data :as data]
    [metabase.test.data.clickhouse :as ctd]))

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -10,6 +10,7 @@
             [metabase.driver :as driver]
             [metabase.driver.clickhouse-base-types-test]
             [metabase.driver.clickhouse-temporal-bucketing-test]
+            [metabase.driver.clickhouse-substitution-test]
             [metabase.driver.common :as driver.common]
             [metabase.driver.sql :as driver.sql]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -23,6 +24,8 @@
             [metabase.test.data.clickhouse :as ctd]
             [taoensso.nippy :as nippy]
             [toucan2.tools.with-temp :as t2.with-temp]))
+
+(set! *warn-on-reflection* true)
 
 (deftest clickhouse-server-timezone
   (mt/test-driver
@@ -724,7 +727,7 @@
    :clickhouse
    (let [query             (data/mbql-query venues {:fields [$id] :order-by [[:asc $id]] :limit 5})
          {compiled :query} (qp/compile-and-splice-parameters query)
-         _pretty            (mdb.query/format-sql compiled :clickhouse)]
+         _pretty           (mdb.query/format-sql compiled :clickhouse)]
      (testing "compiled"
        (is (= "SELECT `test_data`.`venues`.`id` AS `id` FROM `test_data`.`venues` ORDER BY `test_data`.`venues`.`id` ASC LIMIT 5" compiled)))
     ;; Ignored due to Metabase bug, see https://github.com/metabase/metabase/issues/34235

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -6,7 +6,6 @@
             [cljc.java-time.offset-date-time :as offset-date-time]
             [cljc.java-time.temporal.chrono-unit :as chrono-unit]
             [clojure.test :refer :all]
-            [metabase.db.query :as mdb.query]
             [metabase.driver :as driver]
             [metabase.driver.clickhouse-base-types-test]
             [metabase.driver.clickhouse-temporal-bucketing-test]
@@ -727,11 +726,8 @@
    :clickhouse
    (let [query             (data/mbql-query venues {:fields [$id] :order-by [[:asc $id]] :limit 5})
          {compiled :query} (qp/compile-and-splice-parameters query)
-         _pretty           (mdb.query/format-sql compiled :clickhouse)]
+         pretty            (driver/prettify-native-form :clickhouse compiled)]
      (testing "compiled"
        (is (= "SELECT `test_data`.`venues`.`id` AS `id` FROM `test_data`.`venues` ORDER BY `test_data`.`venues`.`id` ASC LIMIT 5" compiled)))
-    ;; Ignored due to Metabase bug, see https://github.com/metabase/metabase/issues/34235
-    ;; FIXME: uncomment once it is resolved
-    ;;  (testing "pretty"
-    ;;    (is (= "SELECT\n `test_data`.`venues`.`id` AS `id`\nFROM `test_data`.`venues`\nORDER BY\n  `test_data`.`venues`.`id` ASC\nLIMIT\n  5" pretty)))
-     )))
+     (testing "pretty"
+       (is (= "SELECT\n  `test_data`.`venues`.`id` AS `id`\nFROM\n  `test_data`.`venues`\nORDER BY\n  `test_data`.`venues`.`id` ASC\nLIMIT\n  5" pretty))))))

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -8,7 +8,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql.util :as sql.u]
    [metabase.models [database :refer [Database]]]
-   [metabase.query-processor-test :as qp.test]
+   [metabase.query-processor.test-util :as qp.test]
    [metabase.sync.sync-metadata :as sync-metadata]
    [metabase.test.data
     [interface :as tx]
@@ -90,7 +90,7 @@
    :ssl false
    :use_no_proxy false
    :use_server_time_zone_for_dates true
-   :product_name "metabase/1.2.2"})
+   :product_name "metabase/1.3.0"})
 
 (defn rows-without-index
   "Remove the Metabase index which is the first column in the result set"

--- a/test/metabase/test/data/datasets.sql
+++ b/test/metabase/test/data/datasets.sql
@@ -1,6 +1,15 @@
 DROP DATABASE IF EXISTS `metabase_test`;
 CREATE DATABASE `metabase_test`;
 
+CREATE TABLE `metabase_test`.`metabase_test_lowercases`
+(
+    id UInt8,
+    mystring Nullable(String)
+) ENGINE = Memory;
+
+INSERT INTO `metabase_test`.`metabase_test_lowercases`
+VALUES (1, 'Я_1'), (2, 'R'), (3, 'Я_2'), (4, 'Я'), (5, 'я'), (6, NULL);
+
 CREATE TABLE `metabase_test`.`enums_test`
 (
     enum1 Enum8('foo' = 0, 'bar' = 1, 'foo bar' = 2),


### PR DESCRIPTION
## Summary
* Adds Metabase 0.48.x support
* Resolves #87 
* Resolves #195 
* Resolves #196

NB: this is based on the changes from https://github.com/metabase/metabase/pull/34873. One test will currently fail: `metabase.query-processor-test.alternative-date-test/substitute-native-parameters-test` (looking for a way to fix it).

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
