### PR TITLE
Fix LowCardinality(Nullable) types introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.3
+
+### Bug fixes
+
+* Fixed `LowCardinality(Nullable)` types introspection, where it was incorrectly reported as `type/*` ([#203](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/203))
+
 # 1.2.2
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker run -d -p 3000:3000 \
 | 0.44.x           | 0.9.1          |
 | 0.45.x           | 1.1.0          |
 | 0.46.x           | 1.1.7          |
-| 0.47.x           | 1.2.2          |
+| 0.47.x           | 1.2.3          |
 
 ## Creating a Metabase Docker image with ClickHouse driver
 

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.2.2
+  version: 1.2.3
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -18,7 +18,7 @@
 (driver/register! :clickhouse :parent :sql-jdbc)
 
 (defmethod driver/display-name :clickhouse [_] "ClickHouse")
-(def ^:private product-name "metabase/1.2.2")
+(def ^:private product-name "metabase/1.2.3")
 
 (doseq [[feature supported?] {:standard-deviation-aggregations true
                               :foreign-keys                    (not config/is-test?)

--- a/test/metabase/driver/clickhouse_base_types_test.clj
+++ b/test/metabase/driver/clickhouse_base_types_test.clj
@@ -236,6 +236,17 @@
                  :database-type "Array(Array(Array(String)))",
                  :name "c4"}}
               (desc-table table-name)))))
+   (testing "low cardinality nullable"
+     (let [table-name "low_cardinality_nullable_base_types"]
+       (is (= #{{:base-type :type/Text,
+                 :database-required true,
+                 :database-type "LowCardinality(Nullable(String))",
+                 :name "c1"}
+                {:base-type :type/TextLike,
+                 :database-required true,
+                 :database-type "LowCardinality(Nullable(FixedString(16)))",
+                 :name "c2"}}
+              (desc-table table-name))))
    (testing "everything else"
      (let [table-name "misc_base_types"]
        (is (= #{{:base-type :type/Boolean,
@@ -278,4 +289,4 @@
                  :database-required true,
                  :database-type "Tuple(String, Int32)",
                  :name "c10"}}
-              (desc-table table-name)))))))
+              (desc-table table-name))))))))

--- a/test/metabase/driver/clickhouse_base_types_test.clj
+++ b/test/metabase/driver/clickhouse_base_types_test.clj
@@ -246,7 +246,7 @@
                  :database-required true,
                  :database-type "LowCardinality(Nullable(FixedString(16)))",
                  :name "c2"}}
-              (desc-table table-name))))
+              (desc-table table-name)))))
    (testing "everything else"
      (let [table-name "misc_base_types"]
        (is (= #{{:base-type :type/Boolean,
@@ -289,4 +289,4 @@
                  :database-required true,
                  :database-type "Tuple(String, Int32)",
                  :name "c10"}}
-              (desc-table table-name))))))))
+              (desc-table table-name)))))))

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -90,7 +90,7 @@
    :ssl false
    :use_no_proxy false
    :use_server_time_zone_for_dates true
-   :product_name "metabase/1.2.2"})
+   :product_name "metabase/1.2.3"})
 
 (defn rows-without-index
   "Remove the Metabase index which is the first column in the result set"

--- a/test/metabase/test/data/datasets.sql
+++ b/test/metabase/test/data/datasets.sql
@@ -218,3 +218,7 @@ CREATE TABLE `metabase_test`.`array_base_types` (
     c3 Array(Array(LowCardinality(FixedString(32)))),
     c4 Array(Array(Array(String)))
 ) ENGINE Memory;
+CREATE TABLE `metabase_test`.`low_cardinality_nullable_base_types` (
+    c1 LowCardinality(Nullable(String)),
+    c2 LowCardinality(Nullable(FixedString(16)))
+) ENGINE Memory;


### PR DESCRIPTION
## Summary
Resolves #203 
DB -> base type introspection is rewritten to be as simple as possible, without regex.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
