### PR TITLE
Simplify can-connect method

### DIFF
--- a/.docker/clickhouse/single_node/users.xml
+++ b/.docker/clickhouse/single_node/users.xml
@@ -18,6 +18,15 @@
       <quota>default</quota>
       <access_management>1</access_management>
     </default>
+    <user_with_password>
+      <password>foo@bar!</password>
+      <networks>
+        <ip>::/0</ip>
+      </networks>
+      <profile>default</profile>
+      <quota>default</quota>
+      <access_management>1</access_management>
+    </user_with_password>
   </users>
 
   <quotas>

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.3.1
+  version: 1.3.2
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -20,7 +20,7 @@
 (driver/register! :clickhouse :parent :sql-jdbc)
 
 (defmethod driver/display-name :clickhouse [_] "ClickHouse")
-(def ^:private product-name "metabase/1.3.1")
+(def ^:private product-name "metabase/1.3.2")
 
 (defmethod driver/prettify-native-form :clickhouse [_ native-form]
   (sql.u/format-sql-and-fix-params :mysql native-form))

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -62,16 +62,11 @@
   [driver details]
   (try
     (let [spec  (sql-jdbc.conn/connection-details->spec driver details)
-          db    (or (:db details) "default")
-          query (format "SHOW DATABASES LIKE '%s'" db)]
+          db    (or (:dbname details) (:db details) "default")]
       (sql-jdbc.execute/do-with-connection-with-options
        driver spec nil
        (fn [^java.sql.Connection conn]
-         (with-open [stmt (.prepareStatement conn query)
-                     rset (.executeQuery stmt)]
-           (if (.next rset)
-             (= db (.getString rset 1))
-             false))))) ;; Empty ResultSet => Database does not exist
+         (.next (.getSchemas (.getMetaData conn) nil db)))))
     (catch Throwable e
       (log/error e "An exception during ClickHouse connectivity check")
       false)))

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -8,8 +8,8 @@
             [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.driver.clickhouse-base-types-test]
-            [metabase.driver.clickhouse-temporal-bucketing-test]
             [metabase.driver.clickhouse-substitution-test]
+            [metabase.driver.clickhouse-temporal-bucketing-test]
             [metabase.driver.common :as driver.common]
             [metabase.driver.sql :as driver.sql]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -762,3 +762,13 @@
                       {"dt64,dt" [:datetime-diff $dt64 $dt :day]
                        "dt64,d"  [:datetime-diff $dt64 $d  :day]}})
                     (mt/formatted-rows [int int])))))))))
+
+(deftest clickhouse-can-connect
+  (mt/test-driver
+   :clickhouse
+   (ctd/create-test-db!)
+   (doall
+    (for [[username password] [["default" ""] ["user_with_password" "foo@bar!"]]
+          database            ["default" "Test Database" "Special@Characters~" "'Escaping'"]]
+      (testing (format "User `%s` can connect to `%s`" username database)
+        (is (true? (driver/can-connect? :clickhouse {:user username :password password :dbname database}))))))))

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -90,7 +90,7 @@
    :ssl false
    :use_no_proxy false
    :use_server_time_zone_for_dates true
-   :product_name "metabase/1.3.1"})
+   :product_name "metabase/1.3.2"})
 
 (defn rows-without-index
   "Remove the Metabase index which is the first column in the result set"

--- a/test/metabase/test/data/datasets.sql
+++ b/test/metabase/test/data/datasets.sql
@@ -244,3 +244,11 @@ CREATE TABLE `metabase_test`.`low_cardinality_nullable_base_types` (
     c1 LowCardinality(Nullable(String)),
     c2 LowCardinality(Nullable(FixedString(16)))
 ) ENGINE Memory;
+
+-- can-connect tests (odd database names)
+DROP DATABASE IF EXISTS `Test Database`;
+CREATE DATABASE `Test Database`;
+DROP DATABASE IF EXISTS `Special@Characters~`;
+CREATE DATABASE `Special@Characters~`;
+DROP DATABASE IF EXISTS `'Escaping'`;
+CREATE DATABASE `'Escaping'`;


### PR DESCRIPTION
## Summary
Related to #212 - trying a different approach with the `can-connect` method implementation.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
