### PR TITLE
Fall back to non-UTF8 string functions with pre-23.8 ClickHouse

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:23.8-alpine
+FROM clickhouse/clickhouse-server:24.1-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,11 +66,24 @@ jobs:
         run: yarn build-static-viz
 
       # Use custom deps.edn containing "user/clickhouse" alias to include driver sources
-      - name: Run tests
+      - name: Prepare deps.edn
         run: |
           mkdir -p /home/runner/.config/clojure
           cat modules/drivers/clickhouse/.github/deps.edn | sed -e "s|PWD|$PWD|g" > /home/runner/.config/clojure/deps.edn
-          DRIVERS=clickhouse clojure -X:dev:drivers:drivers-dev:test:user/clickhouse
+
+      - name: Run ClickHouse driver tests with 23.3
+        env:
+          DRIVERS: clickhouse
+          MB_CLICKHOUSE_TEST_PORT: 8124
+          MB_CLICKHOUSE_TEST_SKIP_CASE_INSENSITIVE_TESTS: 1
+        run: |
+          clojure -X:dev:drivers:drivers-dev:test:user/clickhouse :only metabase.driver.clickhouse-test
+
+      - name: Run all tests with the latest ClickHouse version
+        env:
+          DRIVERS: clickhouse
+        run: |
+          clojure -X:dev:drivers:drivers-dev:test:user/clickhouse
 
       - name: Build ClickHouse driver
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.4
+
+### New features
+
+* If introspected ClickHouse version is lower than 23.8, the driver will not use the UTF8 versions of string functions ([startsWithUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-functions#startswithutf8), [lowerUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-functions#lowerutf8), [positionUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#positionutf8), [positionCaseInsensitiveUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#positioncaseinsensitiveutf8)) and fall back to their non-UTF8 counterparts instead. An expected drawback of this compatibility mode: potentially incorrect filtering results when working with non-latin strings. If your use case includes filtering by columns with such strings, consider upgrading your ClickHouse server to 23.8+. ([#224](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/224))
+
 # 1.3.3
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker run -d -p 3000:3000 \
 | 0.46.x           | 1.1.7          |
 | 0.47.x           | 1.2.3          |
 | 0.47.7+          | 1.2.5          |
-| 0.48.x           | 1.3.2          |
+| 0.48.x           | 1.3.4          |
 
 ## Creating a Metabase Docker image with ClickHouse driver
 
@@ -142,6 +142,7 @@ The driver should work fine for many use cases. Please consider the following it
 
 * As the underlying JDBC driver version does not support columns with `AggregateFunction` type, these columns are excluded from the table metadata and data browser result sets to prevent sync or data browsing errors.
 * If the past month/week/quarter/year filter over a DateTime64 column is not working as intended, this is likely due to a [type conversion issue](https://github.com/ClickHouse/ClickHouse/pull/50280). See [this report](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/164) for more details. This issue was resolved as of ClickHouse 23.5.
+* If introspected ClickHouse version is lower than 23.8, the driver will not use the UTF8 versions of string functions ([startsWithUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-functions#startswithutf8), [lowerUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-functions#lowerutf8), [positionUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#positionutf8), [positionCaseInsensitiveUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#positioncaseinsensitiveutf8)) and fall back to their non-UTF8 counterparts instead. An expected drawback of this compatibility mode: potentially incorrect filtering results when working with non-latin strings. If your use case includes filtering by columns with such strings, consider upgrading your ClickHouse server to 23.8+.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,26 @@
 version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:23.8-alpine'
+    image: 'clickhouse/clickhouse-server:24.1-alpine'
     container_name: 'metabase-driver-clickhouse-server'
     ports:
       - '8123:8123'
       - '9000:9000'
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - './.docker/clickhouse/single_node/config.xml:/etc/clickhouse-server/config.xml'
+      - './.docker/clickhouse/single_node/users.xml:/etc/clickhouse-server/users.xml'
+
+  # For testing pre-23.8 string functions switch between UTF8 and non-UTF8 versions (see clickhouse_qp.clj)
+  clickhouse_older_version:
+    image: 'clickhouse/clickhouse-server:23.3-alpine'
+    container_name: 'metabase-driver-clickhouse-server-older-version'
+    ports:
+      - '8124:8123'
+      - '9001:9000'
     ulimits:
       nofile:
         soft: 262144

--- a/src/metabase/driver/clickhouse_qp.clj
+++ b/src/metabase/driver/clickhouse_qp.clj
@@ -5,13 +5,16 @@
             [honey.sql :as sql]
             [java-time.api :as t]
             [metabase [util :as u]]
+            [metabase.driver :as driver]
             [metabase.driver.clickhouse-nippy]
             [metabase.driver.common.parameters.dates :as params.dates]
             [metabase.driver.sql-jdbc [execute :as sql-jdbc.execute]]
             [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
             [metabase.driver.sql.query-processor :as sql.qp :refer [add-interval-honeysql-form]]
             [metabase.driver.sql.util.unprepare :as unprepare]
+            [metabase.lib.metadata :as lib.metadata]
             [metabase.mbql.util :as mbql.u]
+            [metabase.query-processor.store :as qp.store]
             [metabase.util.date-2 :as u.date]
             [metabase.util.honey-sql-2 :as h2x]
             [metabase.util.log :as log])
@@ -30,6 +33,18 @@
 
 (defmethod sql.qp/quote-style       :clickhouse [_] :mysql)
 (defmethod sql.qp/honey-sql-version :clickhouse [_] 2)
+
+(defn- clickhouse-version []
+  (let [db (lib.metadata/database (qp.store/metadata-provider))]
+    (qp.store/cached ::clickhouse-version (driver/dbms-version :clickhouse db))))
+
+(defn- with-min-version [major minor default-fn fallback-fn]
+  (let [version (clickhouse-version)]
+    (if (or (> (get-in version [:semantic-version :major]) major)
+            (and (= (get-in version [:semantic-version :major]) major)
+                 (>= (get-in version [:semantic-version :minor]) minor)))
+      default-fn
+      fallback-fn)))
 
 (defmethod sql.qp/date [:clickhouse :day-of-week]
   [_ _ expr]
@@ -282,26 +297,30 @@
 (defn- clickhouse-string-fn
   [fn-name field value options]
   (let [hsql-field (sql.qp/->honeysql :clickhouse field)
-        hsql-value (sql.qp/->honeysql :clickhouse value)]
+        hsql-value (sql.qp/->honeysql :clickhouse value)
+        lower (with-min-version 23 8 :'lowerUTF8 :'lower)]
     (if (get options :case-sensitive true)
       [fn-name hsql-field hsql-value]
-      [fn-name [:'lowerUTF8 hsql-field] [:'lowerUTF8 hsql-value]])))
+      [fn-name [lower hsql-field] [lower hsql-value]])))
 
 (defmethod sql.qp/->honeysql [:clickhouse :starts-with]
   [_ [_ field value options]]
-  (clickhouse-string-fn :'startsWithUTF8 field value options))
+  (let [starts-with (with-min-version 23 8 :'startsWithUTF8 :'startsWith)]
+    (clickhouse-string-fn starts-with field value options)))
 
 (defmethod sql.qp/->honeysql [:clickhouse :ends-with]
   [_ [_ field value options]]
-  (clickhouse-string-fn :'endsWithUTF8 field value options))
+  (let [ends-with (with-min-version 23 8 :'endsWithUTF8 :'endsWith)]
+    (clickhouse-string-fn ends-with field value options)))
 
 (defmethod sql.qp/->honeysql [:clickhouse :contains]
   [_ [_ field value options]]
   (let [hsql-field (sql.qp/->honeysql :clickhouse field)
-        hsql-value (sql.qp/->honeysql :clickhouse value)]
-    (if (get options :case-sensitive true)
-      [:> [:'positionUTF8                hsql-field hsql-value] 0]
-      [:> [:'positionCaseInsensitiveUTF8 hsql-field hsql-value] 0])))
+        hsql-value (sql.qp/->honeysql :clickhouse value)
+        position-fn (if (get options :case-sensitive true)
+                      (with-min-version 23 8 :'positionUTF8 :'position)
+                      (with-min-version 23 8 :'positionCaseInsensitiveUTF8 :'positionCaseInsensitive))]
+    [:> [position-fn hsql-field hsql-value] 0]))
 
 (defmethod sql.qp/->honeysql [:clickhouse :datetime-diff]
   [driver [_ x y unit]]

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -21,6 +21,17 @@
 
 (sql-jdbc.tx/add-test-extensions! :clickhouse)
 
+(def default-connection-params
+  {:classname "com.clickhouse.jdbc.ClickHouseDriver"
+   :subprotocol "clickhouse"
+   :subname "//localhost:8123/default"
+   :user "default"
+   :password ""
+   :ssl false
+   :use_no_proxy false
+   :use_server_time_zone_for_dates true
+   :product_name "metabase/1.3.4"})
+
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Char]       [_ _] "String")
@@ -81,41 +92,25 @@
 
 (defmethod tx/supports-time-type? :clickhouse [_driver] false)
 
-(def default-connection-params
-  {:classname "com.clickhouse.jdbc.ClickHouseDriver"
-   :subprotocol "clickhouse"
-   :subname "//localhost:8123/default"
-   :user "default"
-   :password ""
-   :ssl false
-   :use_no_proxy false
-   :use_server_time_zone_for_dates true
-   :product_name "metabase/1.3.3"})
-
 (defn rows-without-index
   "Remove the Metabase index which is the first column in the result set"
   [query-result]
   (map #(drop 1 %) (qp.test/rows query-result)))
-
-(defn- test-db-details
-  []
-  {:engine :clickhouse
-   :details (tx/dbdef->connection-details
-             :clickhouse :db {:database-name "metabase_test"})})
 
 (def ^:private test-db-initialized? (atom false))
 (defn create-test-db!
   "Create a ClickHouse database called `metabase_test` and initialize some test data"
   []
   (when (not @test-db-initialized?)
-    (jdbc/with-db-connection
-      [conn (sql-jdbc.conn/connection-details->spec :clickhouse (test-db-details))]
-      (let [statements (as-> (slurp "modules/drivers/clickhouse/test/metabase/test/data/datasets.sql") s
-                         (str/split s #";")
-                         (map str/trim s)
-                         (filter seq s))]
-        (jdbc/db-do-commands conn statements)
-        (reset! test-db-initialized? true)))))
+    (let [details (tx/dbdef->connection-details :clickhouse :db {:database-name "metabase_test"})]
+      (jdbc/with-db-connection
+        [conn (sql-jdbc.conn/connection-details->spec :clickhouse (merge {:engine :clickhouse} details))]
+        (let [statements (as-> (slurp "modules/drivers/clickhouse/test/metabase/test/data/datasets.sql") s
+                           (str/split s #";")
+                           (map str/trim s)
+                           (filter seq s))]
+          (jdbc/db-do-commands conn statements)
+          (reset! test-db-initialized? true))))))
 
 (defn do-with-test-db
   "Execute a test function using the test dataset"
@@ -123,6 +118,8 @@
   [f]
   (create-test-db!)
   (t2.with-temp/with-temp
-    [Database database (test-db-details)]
+    [Database database
+     {:engine :clickhouse
+      :details (tx/dbdef->connection-details :clickhouse :db {:database-name "metabase_test"})}]
     (sync-metadata/sync-db-metadata! database)
     (f database)))


### PR DESCRIPTION
## Summary

Resolves #224.

* If introspected ClickHouse version is lower than 23.8, the driver will not use the UTF8 versions of string functions ([startsWithUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-functions#startswithutf8), [lowerUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-functions#lowerutf8), [positionUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#positionutf8), [positionCaseInsensitiveUTF8](https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#positioncaseinsensitiveutf8)) and fall back to their non-UTF8 counterparts instead. An expected drawback of this compatibility mode: potentially incorrect filtering results when working with non-latin strings.
* Added CI with ClickHouse 23.3 (current "LTS"), disabling one test that is expected to fail.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
