### PR TITLE
Remove redundant substitutions override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.1
+
+### Bug fixes
+
+* Fixed missing data for the last day when using filters with DateTime columns. ([#202](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/202), [#229](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/229))
+
 # 1.4.0
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@
 6. Make sure you are the in the directory where your `metabase.jar` lives.
 7. Run `MB_PLUGINS_DIR=./plugins; java -jar metabase.jar`.
 
-For example [(using Metabase v0.47.2 and ClickHouse driver 1.2.2)](#choosing-the-right-version):
+For example [(using Metabase v0.49.3 and ClickHouse driver 1.4.1)](#choosing-the-right-version):
 
 ```bash
-export METABASE_VERSION=v0.47.2
-export METABASE_CLICKHOUSE_DRIVER_VERSION=1.2.2
+export METABASE_VERSION=v0.49.3
+export METABASE_CLICKHOUSE_DRIVER_VERSION=1.4.1
 
 mkdir -p mb/plugins && cd mb
 curl -o metabase.jar https://downloads.metabase.com/$METABASE_VERSION/metabase.jar
@@ -49,8 +49,8 @@ MB_PLUGINS_DIR=./plugins; java -jar metabase.jar
 Alternatively, if you don't want to run Metabase Jar, you can use a Docker image:
 
 ```bash
-export METABASE_DOCKER_VERSION=v0.47.2
-export METABASE_CLICKHOUSE_DRIVER_VERSION=1.2.2
+export METABASE_DOCKER_VERSION=v0.49.3
+export METABASE_CLICKHOUSE_DRIVER_VERSION=1.4.1
 
 mkdir -p mb/plugins && cd mb
 curl -L -o plugins/ch.jar https://github.com/ClickHouse/metabase-clickhouse-driver/releases/download/$METABASE_CLICKHOUSE_DRIVER_VERSION/clickhouse.metabase-driver.jar
@@ -77,17 +77,17 @@ docker run -d -p 3000:3000 \
 | 0.47.x           | 1.2.3          |
 | 0.47.7+          | 1.2.5          |
 | 0.48.x           | 1.3.4          |
-| 0.49.x           | 1.4.0          |
+| 0.49.x           | 1.4.1          |
 
 ## Creating a Metabase Docker image with ClickHouse driver
 
 You can use a convenience script `build_docker_image.sh`, which takes three arguments: Metabase version, ClickHouse driver version, and the desired final Docker image tag.
 
 ```bash
-./build_docker_image.sh v0.47.2 1.2.2 my-metabase-with-clickhouse:v0.0.1
+./build_docker_image.sh v0.49.3 1.4.1 my-metabase-with-clickhouse:v0.0.1
 ```
 
-where `v0.47.2` is Metabase version, `1.2.2` is ClickHouse driver version, and `my-metabase-with-clickhouse:v0.0.1` being the tag.
+where `v0.49.3` is Metabase version, `1.3.3` is ClickHouse driver version, and `my-metabase-with-clickhouse:v0.0.1` being the tag.
 
 Then you should be able to run it:
 
@@ -101,7 +101,7 @@ or use it with Docker compose, for example:
 version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:23.8-alpine'
+    image: 'clickhouse/clickhouse-server:24.3-alpine'
     container_name: 'metabase-clickhouse-server'
     ports:
       - '8123:8123'
@@ -113,6 +113,10 @@ services:
   metabase:
     image: 'my-metabase-with-clickhouse:v0.0.1'
     container_name: 'metabase-with-clickhouse'
+    environment:
+      'MB_HTTP_TIMEOUT': '5000'
+      # Replace with a timezone matching your ClickHouse or DateTime columns timezone
+      'JAVA_TIMEZONE': 'UTC'
     ports:
       - '3000:3000'
 ```
@@ -137,7 +141,6 @@ The driver should work fine for many use cases. Please consider the following it
 * Consider running the Metabase instance in the same time zone as your ClickHouse database; the more time zones involved the more issues.
 * Compare the results of the queries with the results returned by `clickhouse-client`.
 * Metabase is a good tool for organizing questions, dashboards etc. and to give non-technical users a good way to explore the data and share their results. The driver cannot support all the cool special features of ClickHouse, e.g. array functions. You are free to use native queries, of course.
-
 
 ## Known limitations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     hostname: server.clickhouseconnect.test
 
   metabase:
-    image: metabase/metabase:v0.49.0-RC2
+    image: metabase/metabase:v0.49.3
     container_name: metabase-with-clickhouse-driver
     environment:
       'MB_HTTP_TIMEOUT': '5000'
@@ -57,3 +57,9 @@ services:
     volumes:
       - '../../../resources/modules/clickhouse.metabase-driver.jar:/plugins/clickhouse.jar'
       - './.docker/clickhouse/single_node_tls/certificates/ca.crt:/certs/ca.crt'
+  postgres:
+    image: postgres
+    # shm_size: 128mb
+    environment:
+      POSTGRES_USER: example
+      POSTGRES_PASSWORD: example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,9 +57,3 @@ services:
     volumes:
       - '../../../resources/modules/clickhouse.metabase-driver.jar:/plugins/clickhouse.jar'
       - './.docker/clickhouse/single_node_tls/certificates/ca.crt:/certs/ca.crt'
-  postgres:
-    image: postgres
-    # shm_size: 128mb
-    environment:
-      POSTGRES_USER: example
-      POSTGRES_PASSWORD: example

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.4.0
+  version: 1.4.1
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -20,7 +20,7 @@
 (driver/register! :clickhouse :parent :sql-jdbc)
 
 (defmethod driver/display-name :clickhouse [_] "ClickHouse")
-(def ^:private product-name "metabase/1.4.0")
+(def ^:private product-name "metabase/1.4.1")
 
 (defmethod driver/prettify-native-form :clickhouse [_ native-form]
   (sql.u/format-sql-and-fix-params :mysql native-form))

--- a/src/metabase/driver/clickhouse_qp.clj
+++ b/src/metabase/driver/clickhouse_qp.clj
@@ -139,20 +139,20 @@
 (defmethod sql.qp/->honeysql [:clickhouse LocalDateTime]
   [_ ^java.time.LocalDateTime t]
   (let [formatted (t/format "yyyy-MM-dd HH:mm:ss.SSS" t)
-        fn (date-time-parse-fn (.getNano t))]
+        fn        (date-time-parse-fn (.getNano t))]
     [fn formatted]))
 
 (defmethod sql.qp/->honeysql [:clickhouse ZonedDateTime]
   [_ ^java.time.ZonedDateTime t]
   (let [formatted (t/format "yyyy-MM-dd HH:mm:ss.SSSZZZZZ" t)
-        fn (date-time-parse-fn (.getNano t))]
+        fn        (date-time-parse-fn (.getNano t))]
     [fn formatted]))
 
 (defmethod sql.qp/->honeysql [:clickhouse OffsetDateTime]
   [_ ^java.time.OffsetDateTime t]
   ;; copy-paste due to reflection warnings
   (let [formatted (t/format "yyyy-MM-dd HH:mm:ss.SSSZZZZZ" t)
-        fn (date-time-parse-fn (.getNano t))]
+        fn        (date-time-parse-fn (.getNano t))]
     [fn formatted]))
 
 (defmethod sql.qp/->honeysql [:clickhouse LocalDate]
@@ -449,7 +449,7 @@
 
 (defmethod unprepare/unprepare-value [:clickhouse LocalDate]
   [_ t]
-  (format "toDate('%s')" (t/format "yyyy-MM-dd" t)))
+  (format "'%s'" (t/format "yyyy-MM-dd" t)))
 
 (defmethod unprepare/unprepare-value [:clickhouse LocalTime]
   [_ t]

--- a/src/metabase/driver/clickhouse_qp.clj
+++ b/src/metabase/driver/clickhouse_qp.clj
@@ -7,9 +7,7 @@
             [metabase [util :as u]]
             [metabase.driver :as driver]
             [metabase.driver.clickhouse-nippy]
-            [metabase.driver.common.parameters.dates :as params.dates]
             [metabase.driver.sql-jdbc [execute :as sql-jdbc.execute]]
-            [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
             [metabase.driver.sql.query-processor :as sql.qp :refer [add-interval-honeysql-form]]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.lib.metadata :as lib.metadata]
@@ -32,7 +30,6 @@
 ;; (set! *warn-on-reflection* true) ;; isn't enabled because of Arrays/toString call
 
 (defmethod sql.qp/quote-style       :clickhouse [_] :mysql)
-(defmethod sql.qp/honey-sql-version :clickhouse [_] 2)
 
 (defn- clickhouse-version []
   (let [db (lib.metadata/database (qp.store/metadata-provider))]
@@ -475,20 +472,3 @@
 (defmethod unprepare/unprepare-value [:clickhouse ZonedDateTime]
   [_ t]
   (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSSZZZZZ" t)))
-
-;; See https://github.com/ClickHouse/metabase-clickhouse-driver/issues/196
-(def ^:private int-base-types [:type/Integer :type/BigInteger])
-(defmethod sql.params.substitution/align-temporal-unit-with-param-type-and-value :clickhouse
-  [_ field param-type value]
-  (cond
-    ;;;; cast to a Date type
-    (or
-     ;; an integer timestamp value,
-     ;; required for `metabase.query-processor-test.alternative-date-test/substitute-native-parameters-test`
-     (and (params.dates/date-type? param-type) (some #(= (:base-type field) %) int-base-types))
-     ;; an ISO Date string value like "2024-01-16"
-     (and (string? value) (= (count value) 10) (boolean (re-matches #"^\d{4}-\d{2}-\d{2}$" value)))) :day
-    ;;;; cast to a DateTime type with minutes precision (for values like "2024-01-16T12:45:00")
-    (and (string? value) (= (count value) 19) (boolean (re-matches #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00$" value))) :minute
-    ;;;; otherwise, don't do any additional cast operations
-    :else nil))

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -65,12 +65,9 @@
 
 (defmethod sql.tx/create-table-sql :clickhouse
   [driver {:keys [database-name]} {:keys [table-name field-definitions]}]
-  (let [quot          #(sql.u/quote-name driver :field (ddl.i/format-name driver %))
-        pk-field-name (quot (sql.tx/pk-field-name driver))]
-    (format "CREATE TABLE %s (%s %s, %s) ENGINE = Memory"
+  (let [quot #(sql.u/quote-name driver :field (ddl.i/format-name driver %))]
+    (format "CREATE TABLE %s (%s) ENGINE = Memory"
             (sql.tx/qualify-and-quote driver database-name table-name)
-            pk-field-name
-            (sql.tx/pk-sql-type driver)
             (->> field-definitions
                  (map (fn [{:keys [field-name base-type]}]
                         (format "%s %s" (quot field-name)
@@ -84,7 +81,7 @@
   (apply execute/sequentially-execute-sql! args))
 
 (defmethod load-data/load-data! :clickhouse [& args]
-  (apply load-data/load-data-add-ids! args))
+ (apply load-data/load-data-maybe-add-ids-chunked! args))
 
 (defmethod sql.tx/pk-sql-type :clickhouse [_] "Nullable(Int32)")
 

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -30,7 +30,7 @@
    :ssl false
    :use_no_proxy false
    :use_server_time_zone_for_dates true
-   :product_name "metabase/1.4.0"})
+   :product_name "metabase/1.4.1"})
 
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")


### PR DESCRIPTION
## Summary
Resolves #229 and #202.
The substitution override is not required after https://github.com/metabase/metabase/pull/38695; it was likely the cause of the reported issues.

WIP: some (unrelated) tests are still failing.

## Checklist
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
