### PR TITLE
CSV uploads for ClickHouse Cloud

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: metabase/metabase
-          ref: v0.49.6
+          ref: v0.49.11
 
       - name: Remove incompatible tests
         # dataset-definition-test tests test data definition,

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -19,7 +19,8 @@
             [metabase.driver.sql.util :as sql.u]
             [metabase.upload :as upload]
             [metabase.util.log :as log])
-  (:import [com.clickhouse.jdbc.internal ClickHouseStatementImpl]))
+  (:import [com.clickhouse.client ClickHouseRequest]
+           [com.clickhouse.jdbc.internal ClickHouseStatementImpl]))
 
 (set! *warn-on-reflection* true)
 
@@ -185,11 +186,11 @@
    {:write? true}
    (fn [^java.sql.Connection conn]
      (with-open [stmt (.createStatement conn)]
-       (let [stmt    (.unwrap stmt ClickHouseStatementImpl)
+       (let [^ClickHouseStatementImpl stmt (.unwrap stmt ClickHouseStatementImpl)
              request (.getRequest stmt)]
-         (.set request "wait_end_of_query" 1)
+         (.set request "wait_end_of_query" "1")
          (with-open [_response (-> request
-                                   (.query (create-table!-sql driver table-name column-definitions :primary-key primary-key))
+                                   (.query ^String (create-table!-sql driver table-name column-definitions :primary-key primary-key))
                                    (.executeAndWait))]))))))
 
 (defmethod driver/insert-into! :clickhouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -175,8 +175,7 @@
                                 :quoted true
                                 :dialect (sql.qp/quote-style driver)))
              "ENGINE = MergeTree"
-             (format "PRIMARY KEY (%s)" (str/join ", " (map quote-name primary-key)))
-             "ORDER BY ()"]))
+             (format "ORDER BY (%s)" (str/join ", " (map quote-name primary-key)))]))
 
 (defmethod driver/create-table! :clickhouse
   [driver db-id table-name column-definitions & {:keys [primary-key]}]

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -185,8 +185,6 @@
                (.addBatch ps)))
            (doall (.executeBatch ps))))))))
 
-(defmethod sql.tx/session-schema :clickhouse [_] "default")
-
 ;;; ------------------------------------------ User Impersonation ------------------------------------------
 
 (defmethod driver.sql/set-role-statement :clickhouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -5,7 +5,6 @@
             [clojure.string :as str]
             [honey.sql :as sql]
             [metabase [config :as config]]
-            [metabase.db.connection :as mdb.connection]
             [metabase.driver :as driver]
             [metabase.driver.clickhouse-introspection]
             [metabase.driver.clickhouse-nippy]
@@ -19,8 +18,7 @@
             [metabase.driver.sql.util :as sql.u]
             [metabase.upload :as upload]
             [metabase.util.log :as log])
-  (:import [com.clickhouse.client ClickHouseRequest]
-           [com.clickhouse.jdbc.internal ClickHouseStatementImpl]))
+  (:import [com.clickhouse.jdbc.internal ClickHouseStatementImpl]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -86,6 +86,9 @@
       :ssl (boolean ssl)
       :use_no_proxy (boolean use-no-proxy)
       :use_server_time_zone_for_dates true
+      ;; select_sequential_consistency is needed to guarantee that we can query data from any replica in CH Cloud
+      ;; immediately after it is written
+      :select_sequential_consistency true
       :product_name product-name}
      (sql-jdbc.common/handle-additional-options details :separator-style :url))))
 

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -113,6 +113,8 @@
 
 (defmethod sql.tx/add-fk-sql :clickhouse [& _] nil) ; TODO - fix me
 
+(defmethod sql.tx/session-schema :clickhouse [_] "default")
+
 (defmethod tx/supports-time-type? :clickhouse [_driver] false)
 
 (defn rows-without-index


### PR DESCRIPTION
## Summary

Issue tracking CSV uploads: https://github.com/ClickHouse/metabase-clickhouse-driver/issues/230

This PR adds support for the `uploads` driver feature for ClickHouse. The feature is currently only supported for ClickHouse Cloud. It requires Metabase x.49.11 to work correctly.

Limitations:
- OffsetDateTime values in the CSV e.g. "2022-01-01T00:00:00+01" are inserted as strings, while in other officially supported drivers they would be inserted as a type with a time zone. This is blocked by #200
- There is no automatically generated primary key column. This is because ClickHouse doesn't support an auto-incrementing type like `SERIAL` in PostgreSQL.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
