### PR TITLE
CSV Uploads: catch failed connections and fix duplicate inserts

### DIFF
--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -99,6 +99,17 @@
               :clickhouse
               {}))))))
 
+(deftest clickhouse-connection-fails-test
+  (mt/test-driver :clickhouse
+    (mt/with-temp [:model/Database db {:details (assoc (mt/db) :password "wrongpassword") :engine :clickhouse}]
+      (testing "Sense check that checking the cloud mode fails with a SQLException."
+        (is (thrown? java.sql.SQLException (clickhouse/cloud? (:details db)))))
+      (testing "`driver/database-supports?` succeeds even if the connection fails."
+        (is (false? (driver/database-supports? :clickhouse :uploads db))))
+      (testing (str "`sql-jdbc.conn/connection-details->spec` succeeds even if the connection fails, "
+                    "and doesn't include the `select_sequential_consistency` parameter.")
+        (is (nil? (:select_sequential_consistency (sql-jdbc.conn/connection-details->spec :clickhouse (:details db)))))))))
+
 (deftest ^:parallel clickhouse-tls
   (mt/test-driver
    :clickhouse

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -103,7 +103,7 @@
   (mt/test-driver :clickhouse
     (mt/with-temp [:model/Database db {:details (assoc (mt/db) :password "wrongpassword") :engine :clickhouse}]
       (testing "Sense check that checking the cloud mode fails with a SQLException."
-        (is (thrown? java.sql.SQLException (clickhouse/cloud? (:details db)))))
+        (is (thrown? java.sql.SQLException (#'clickhouse/cloud? (:details db)))))
       (testing "`driver/database-supports?` succeeds even if the connection fails."
         (is (false? (driver/database-supports? :clickhouse :uploads db))))
       (testing (str "`sql-jdbc.conn/connection-details->spec` succeeds even if the connection fails, "


### PR DESCRIPTION
This PR fixes two issues:

1. Fixes https://github.com/ClickHouse/metabase-clickhouse-driver/issues/237. This is tested in the Metabase repo with a new test added by https://github.com/metabase/metabase/pull/42918
2. Fixes an issue introduced by https://github.com/ClickHouse/metabase-clickhouse-driver/pull/236 where if the DB details don't lead to a successful connection, much of Metabase will be rendered completely unusable because of an uncaught exception from the new `cloud?` function.
