### PR TITLE
Remove `allow_experimental_analyzer=0` setting

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:24.5-alpine
+FROM clickhouse/clickhouse-server:24.7-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.50.3
+
+### Improvements
+
+* The driver no longer explicitly sets `allow_experimental_analyzer=0` settings on the connection level; the [new ClickHouse analyzer](https://clickhouse.com/docs/en/operations/analyzer) is now enabled by default.
+
 # 1.50.2
 
 ### Bug fixes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   ##########################################################################################################
 
   clickhouse:
-    image: 'clickhouse/clickhouse-server:24.5-alpine'
+    image: 'clickhouse/clickhouse-server:24.7-alpine'
     container_name: 'metabase-driver-clickhouse-server'
     hostname: clickhouse
     ports:
@@ -66,7 +66,7 @@ services:
   ##########################################################################################################
 
   clickhouse_cluster_node1:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.5-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.7-alpine}'
     ulimits:
       nofile:
         soft: 262144
@@ -83,7 +83,7 @@ services:
       - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'
 
   clickhouse_cluster_node2:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.5-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.7-alpine}'
     ulimits:
       nofile:
         soft: 262144

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.50.2
+  version: 1.50.3
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -74,9 +74,7 @@
       ;; and https://github.com/ClickHouse/clickhouse-java/issues/1634#issuecomment-2110392634
       :databaseTerm "schema"
       :remember_last_set_roles true
-      :http_connection_provider "HTTP_URL_CONNECTION"
-      ;; See https://github.com/ClickHouse/ClickHouse/issues/64487
-      :custom_http_params "allow_experimental_analyzer=0"}
+      :http_connection_provider "HTTP_URL_CONNECTION"}
      (sql-jdbc.common/handle-additional-options details :separator-style :url))))
 
 (defmethod sql-jdbc.execute/do-with-connection-with-options :clickhouse
@@ -87,10 +85,9 @@
    options
    (fn [^java.sql.Connection conn]
      (when-not (sql-jdbc.execute/recursive-connection?)
-       (let [settings (if session-timezone
-                        (format "allow_experimental_analyzer=0,session_timezone=%s" session-timezone)
-                        "allow_experimental_analyzer=0")]
-         (.setClientInfo conn com.clickhouse.jdbc.ClickHouseConnection/PROP_CUSTOM_HTTP_PARAMS settings))
+       (when session-timezone
+         (.setClientInfo conn com.clickhouse.jdbc.ClickHouseConnection/PROP_CUSTOM_HTTP_PARAMS
+                         (format "session_timezone=%s" session-timezone)))
 
        (sql-jdbc.execute/set-best-transaction-level! driver conn)
        (sql-jdbc.execute/set-time-zone-if-supported! driver conn session-timezone)

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -29,7 +29,7 @@
 (driver/register! :clickhouse :parent #{:sql-jdbc})
 
 (defmethod driver/display-name :clickhouse [_] "ClickHouse")
-(def ^:private product-name "metabase/1.50.2")
+(def ^:private product-name "metabase/1.50.3")
 
 (defmethod driver/prettify-native-form :clickhouse
   [_ native-form]

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -31,7 +31,7 @@
    :ssl false
    :use_no_proxy false
    :use_server_time_zone_for_dates true
-   :product_name "metabase/1.50.2"
+   :product_name "metabase/1.50.3"
    :databaseTerm "schema"
    :remember_last_set_roles true
    :http_connection_provider "HTTP_URL_CONNECTION"})

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -34,8 +34,7 @@
    :product_name "metabase/1.50.2"
    :databaseTerm "schema"
    :remember_last_set_roles true
-   :http_connection_provider "HTTP_URL_CONNECTION"
-   :custom_http_params "allow_experimental_analyzer=0"})
+   :http_connection_provider "HTTP_URL_CONNECTION"})
 
 ;; (def ^:private time-type-comment "COMMENT 'time'")
 ;; (def ^:private time-type (format "DateTime64(3) %s" time-type-comment))


### PR DESCRIPTION
## Summary

Related: #260 

The analyzer probably fixes it. It used to be disabled only because of this issue: https://github.com/ClickHouse/ClickHouse/issues/64487

The tests are working as expected, even when the analyzer is enabled.