### PR TITLE
Fix error uploading offset datetime

### DIFF
--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -202,7 +202,7 @@
     ::upload/boolean                  "Nullable(Boolean)"
     ::upload/date                     "Nullable(Date32)"
     ::upload/datetime                 "Nullable(DateTime64(3))"
-    ::upload/offset-datetime          "Nullable(DateTime64(3))"))
+    ::upload/offset-datetime          nil))
 
 (defmethod driver/table-name-length-limit :clickhouse
   [_driver]
@@ -266,6 +266,7 @@
                    java.math.BigInteger     (.setObject ps idx v)
                    java.time.LocalDate      (.setObject ps idx v)
                    java.time.LocalDateTime  (.setObject ps idx v)
+                   java.time.OffsetDateTime (.setObject ps idx v)
                    (.setString ps idx v)))
                (.addBatch ps)))
            (doall (.executeBatch ps))))))))

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -267,7 +267,7 @@
                    java.time.LocalDate      (.setObject ps idx v)
                    java.time.LocalDateTime  (.setObject ps idx v)
                    java.time.OffsetDateTime (.setObject ps idx v)
-                   (.setString ps idx v)))
+                   (.setString ps idx (.toString v))))
                (.addBatch ps)))
            (doall (.executeBatch ps))))))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/47007

### Description

Without this change Metabase will throw the following error when uploading a CSV with a datetime with an offset value:

```
class java.time.OffsetDateTime` cannot be cast to class `java.lang.String`
```

This is because we were missing a case in the insert method, and it was falling through the the catch all case. The first fix is to add an explicit case for this type to fix the JDBC integration.

The second fix is to update the config for how we map CSV columns to database types in particular. Since Clickhouse does not preserve the input offset, we made the product choice to keep these values as their raw input string. By returning `nil` for this type we can trigger this behavior.

### Testing

I am not sure how to get this tested (incl the CSV upload path) in CI.

I have tested manually in my local dev environment, and it works.