### PR TITLE
Fix NPE on inserting missing values

### DIFF
--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -267,7 +267,7 @@
                    java.time.LocalDate      (.setObject ps idx v)
                    java.time.LocalDateTime  (.setObject ps idx v)
                    java.time.OffsetDateTime (.setObject ps idx v)
-                   (.setString ps idx (.toString v))))
+                   (.setString ps idx (str v))))
                (.addBatch ps)))
            (doall (.executeBatch ps))))))))
 


### PR DESCRIPTION
## Summary

Unfortunately there was a regression in [this commit](https://github.com/ClickHouse/metabase-clickhouse-driver/commit/b1557fa570587adde8f5b19d7adea46d4c71d47d) in 1.50.4 when inserting missing values.
