### PR TITLE
Fix support for Metabase CI and future-proof DDL statements

### DIFF
--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -262,35 +262,6 @@
                                    (.query ^String (create-table!-sql driver table-name column-definitions :primary-key primary-key))
                                    (.executeAndWait))]))))))
 
-(defmethod driver/add-columns! :clickhouse
-  [driver db-id table-name column-definitions & {:as _opts}]
-  (with-quoting driver
-    (let [sql (first (sql/format
-                      {:alter-table (keyword table-name)
-                       :add-column (map (fn [[column-name type-and-constraints]]
-                                          (vec (cons (quote-identifier column-name)
-                                                     (if (string? type-and-constraints)
-                                                       [[:raw type-and-constraints]]
-                                                       type-and-constraints))))
-                                        column-definitions)}
-                      :quoted true
-                      :dialect (sql.qp/quote-style driver)))]
-      (qp.writeback/execute-write-sql! db-id sql))))
-
-
-(defmethod sql-jdbc.sync/alter-columns-sql :clickhouse
-  [driver table-name column-definitions]
-  (with-quoting driver
-    (first (sql/format {:alter-table  (keyword table-name)
-                        :alter-column (map (fn [[column-name type-and-constraints]]
-                                             (vec (cons (quote-identifier column-name)
-                                                        (if (string? type-and-constraints)
-                                                          [[:raw type-and-constraints]]
-                                                          type-and-constraints))))
-                                           column-definitions)}
-                       :quoted true
-                       :dialect (sql.qp/quote-style driver)))))
-
 (defmethod driver/insert-into! :clickhouse
   [driver db-id table-name column-names values]
   (when (seq values)

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -262,7 +262,7 @@
                                    (.query ^String (create-table!-sql driver table-name column-definitions :primary-key primary-key))
                                    (.executeAndWait))]))))))
 
-(defmethod driver/add-columns! :sql-jdbc
+(defmethod driver/add-columns! :clickhouse
   [driver db-id table-name column-definitions & {:as _opts}]
   (with-quoting driver
     (let [sql (first (sql/format

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -238,7 +238,9 @@
               [(first (sql/format {:create-table (keyword table-name)
                                    :with-columns (mapv (fn [[col-name type-spec]]
                                                          (vec (cons (quote-identifier col-name)
-                                                                    [[:raw type-spec]])))
+                                                                    (if (string? type-spec)
+                                                                      [[:raw type-spec]]
+                                                                      type-spec))))
                                                        column-definitions)}
                                   :quoted true
                                   :dialect (sql.qp/quote-style driver)))

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -41,6 +41,7 @@
                               :set-timezone                    true
                               :convert-timezone                true
                               :test/jvm-timezone-setting       false
+                              :test/time-type                  false
                               :schemas                         true
                               :datetime-diff                   true
                               :upload-with-auto-pk             false
@@ -190,7 +191,8 @@
 
 (defmethod ddl.i/format-name :clickhouse
   [_ table-or-field-name]
-  (str/replace table-or-field-name #"-" "_"))
+  (when table-or-field-name
+    (str/replace table-or-field-name #"-" "_")))
 
 ;;; ------------------------------------------ Connection Impersonation ------------------------------------------
 
@@ -261,6 +263,7 @@
              (when (seq row)
                (doseq [[idx v] (map-indexed (fn [x y] [(inc x) y]) row)]
                  (condp isa? (type v)
+                   nil                      (.setString ps idx nil)
                    java.lang.String         (.setString ps idx v)
                    java.lang.Boolean        (.setBoolean ps idx v)
                    java.lang.Long           (.setLong ps idx v)

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -220,13 +220,13 @@
 (defn- create-table!-sql
   "Creates a ClickHouse table with the given name and column definitions. It assumes the engine is MergeTree,
    so it only works with Clickhouse Cloud and single node on-premise deployments at the moment."
-  [driver table-name column-definitions & {:keys [primary-key] :as opts}]
+  [_driver table-name column-definitions & {:keys [primary-key] :as opts}]
   (str/join "\n"
-              [(#'sql-jdbc/create-table!-sql :sql-jdbc table-name column-definitions opts)
-               "ENGINE = MergeTree"
-               (format "ORDER BY (%s)" (str/join ", " (map quote-name primary-key)))
-               ;; disable insert idempotency to allow duplicate inserts
-               "SETTINGS replicated_deduplication_window = 0"]))
+            [(#'sql-jdbc/create-table!-sql :sql-jdbc table-name column-definitions opts)
+             "ENGINE = MergeTree"
+             (format "ORDER BY (%s)" (str/join ", " (map quote-name primary-key)))
+             ;; disable insert idempotency to allow duplicate inserts
+             "SETTINGS replicated_deduplication_window = 0"]))
 
 (defmethod driver/create-table! :clickhouse
   [driver db-id table-name column-definitions & {:keys [primary-key]}]
@@ -290,8 +290,7 @@
         quoted-role (->> (clojure.string/split role #",")
                          (map quote-if-needed)
                          (clojure.string/join ","))]
-    (format "SET ROLE %s;" quoted-role))
-  )
+    (format "SET ROLE %s;" quoted-role)))
 
 (defmethod driver.sql/default-database-role :clickhouse
   [_ _]

--- a/test/metabase/driver/clickhouse_impersonation_test.clj
+++ b/test/metabase/driver/clickhouse_impersonation_test.clj
@@ -31,9 +31,9 @@
       (is true))
     (testing "does not throw with a role containing hyphens"
       (sql-jdbc.execute/do-with-connection-with-options
-        :clickhouse spec nil
-        (fn [^java.sql.Connection conn]
-          (driver/set-role! :clickhouse conn "metabase-test-role")))
+       :clickhouse spec nil
+       (fn [^java.sql.Connection conn]
+         (driver/set-role! :clickhouse conn "metabase-test-role")))
       (is true))
     (testing "does not throw with the default role"
       (sql-jdbc.execute/do-with-connection-with-options

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -150,7 +150,7 @@
   (mt/test-driver
    :clickhouse
    (let [query             (data/mbql-query venues {:fields [$id] :order-by [[:asc $id]] :limit 5})
-         {compiled :query} (qp.compile/compile-and-splice-parameters query)
+         {compiled :query} (qp.compile/compile-with-inline-parameters query)
          pretty            (driver/prettify-native-form :clickhouse compiled)]
      (testing "compiled"
        (is (= "SELECT `test_data`.`venues`.`id` AS `id` FROM `test_data`.`venues` ORDER BY `test_data`.`venues`.`id` ASC LIMIT 5" compiled)))

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -125,16 +125,14 @@
 (defmethod execute/execute-sql! :clickhouse [& args]
   (apply execute/sequentially-execute-sql! args))
 
-(defmethod load-data/load-data! :clickhouse [& args]
-  (apply load-data/load-data-maybe-add-ids-chunked! args))
+(defmethod load-data/row-xform :clickhouse [_driver _dbdef tabledef]
+  (apply load-data/maybe-add-ids-xform tabledef))
 
 (defmethod sql.tx/pk-sql-type :clickhouse [_] "Int32")
 
 (defmethod sql.tx/add-fk-sql :clickhouse [& _] nil)
 
 (defmethod sql.tx/session-schema :clickhouse [_] "default")
-
-(defmethod tx/supports-time-type? :clickhouse [_driver] false)
 
 (defn rows-without-index
   "Remove the Metabase index which is the first column in the result set"

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -126,7 +126,7 @@
   (apply execute/sequentially-execute-sql! args))
 
 (defmethod load-data/row-xform :clickhouse [_driver _dbdef tabledef]
-  (apply load-data/maybe-add-ids-xform tabledef))
+  (load-data/maybe-add-ids-xform tabledef))
 
 (defmethod sql.tx/pk-sql-type :clickhouse [_] "Int32")
 


### PR DESCRIPTION
## Summary

This PR started as future proofing for an upcoming HoneySQL update which requires explicit quoting of identifiers in some cases.

As part of this work I got the main Metabase upload's test suite running against the driver. This required some updates to the driver to track interface changes, and also revealed some small bugs, which have also been fixed.

~~**NOTE: this version will not be safe for v50 without further changes.**~~ Confirmed that this works with the upcoming version of v50.

## Checklist

- [x] There is test coverage for these changes in the main metabase.upload test suite.
