### PR TITLE
Some more test fixes:

### DIFF
--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -149,7 +149,7 @@
       ;; Default SELECT 1 is not enough for Metabase test suite,
       ;; as it works slightly differently than expected there
       (let [spec  (sql-jdbc.conn/connection-details->spec driver details)
-            db    (or (:dbname details) (:db details) "default")]
+            db    (ddl.i/format-name driver (or (:dbname details) (:db details) "default"))]
         (sql-jdbc.execute/do-with-connection-with-options
          driver spec nil
          (fn [^java.sql.Connection conn]

--- a/src/metabase/driver/clickhouse_introspection.clj
+++ b/src/metabase/driver/clickhouse_introspection.clj
@@ -50,8 +50,8 @@
     (normalize-db-type (subs db-type 9 (- (count db-type) 1)))
     ;; for test purposes only: GMT0 is a legacy timezone;
     ;; it maps to LocalDateTime instead of OffsetDateTime
-    (= db-type "datetime64(3, 'gmt0')")
-    :type/DateTime
+    ;; (= db-type "datetime64(3, 'gmt0')")
+    ;; :type/DateTime
     ;; DateTime64
     (str/starts-with? db-type "datetime64")
     :type/DateTimeWithLocalTZ

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -5,6 +5,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
@@ -12,6 +13,7 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.util :as sql.u]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.query-processor-test.alternative-date-test :as qp.alternative-date-test]
    [metabase.query-processor.test-util :as qp.test]
    [metabase.sync.core :as sync]
    [metabase.test.data.interface :as tx]
@@ -30,6 +32,15 @@
   [_driver _feature _db] true)
 (defmethod driver/database-supports? [:clickhouse :metabase.driver.sql-jdbc.sync.describe-table-test/describe-materialized-view-fields]
   [_driver _feature _db] false)
+
+(defmethod driver/database-supports? [:clickhouse :metabase.query-processor-test.parameters-test/get-parameter-count]
+  [_driver _feature _db] false)
+
+(defmethod qp.alternative-date-test/iso-8601-text-fields-expected-rows :clickhouse
+  [_driver]
+  [[1 "foo" (t/offset-date-time "2004-10-19T10:23:54Z") #t "2004-10-19" (t/offset-date-time "1970-01-01T10:23:54Z")]
+   [2 "bar" (t/offset-date-time "2008-10-19T10:23:54Z") #t "2008-10-19" (t/offset-date-time "1970-01-01T10:23:54Z")]
+   [3 "baz" (t/offset-date-time "2012-10-19T10:23:54Z") #t "2012-10-19" (t/offset-date-time "1970-01-01T10:23:54Z")]])
 
 (def default-connection-params
   {:classname "com.clickhouse.jdbc.ClickHouseDriver"


### PR DESCRIPTION
1. use ddl.i/format-name. One of our tests verified we can connect. This failed on a database called `test-data` which was turned into `test_data` in clickhouse.

2. Comment out datetime64, gmt0 mapping to column without timezone. This has a timezone and that is necessary in `metabase.query-processor-test.timezones-test/filter-test`. This sets expectations about which timezone to use. It should use timezones if specified and fall back to report timezone. But we ignore timezones if the column doesn't have a timezone.

3. Turn off tests which expect parameter-count feature

4. Set some different results for a test where we get offset-date-times back
