### PR TITLE
fix: Update clickhouse-client version to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Bug fixes
+
+* Update clickhouse-client to 0.8.1 ([#297](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/297), [#288](https://github.com/ClickHouse/metabase-clickhouse-driver/issues/288)) to fix errors in queries with CTEs.
+
 # 1.53.1
 
 ### Bug fixes

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
  :deps
  {com.widdindustries/cljc.java-time {:mvn/version "0.1.21"}
-  com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.0"}
+  com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.1"}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}


### PR DESCRIPTION
## Summary

Version 0.8.0 that we currently use has a bug [1] that manifests itself as an error when trying to execute queries that contain common table expressions.

[1] https://github.com/ClickHouse/clickhouse-java/issues/2132

Fixes #288 and #297

## Checklist

- [x] A human-readable description of the changes was provided to include in CHANGELOG
