### PR TITLE
1.53.3: Remove http/https schema from the host config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.53.3
+
+### Improvements
+
+* If ClickHouse instance hostname was specified including `http://` or `https://` schema (e.g. `https://sub.example.com`), it will be automatically handled and removed by the driver, instead of failing with a connection error.
+
 # 1.53.2
 
 ### Bug fixes

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 1.53.2
+  version: 1.53.3
   description: Allows Metabase to connect to ClickHouse databases.
 contact-info:
   name: ClickHouse

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -76,8 +76,28 @@
     (testing "nil dbname handling"
       (is (= ctd/default-connection-params
              (sql-jdbc.conn/connection-details->spec
-              :clickhouse
-              {:dbname nil}))))))
+              :clickhouse {:dbname nil}))))
+    (testing "schema removal"
+      (doall
+       (for [host ["localhost" "http://localhost" "https://localhost"]]
+        (testing (str "for host " host)
+          (is (= ctd/default-connection-params
+                 (sql-jdbc.conn/connection-details->spec
+                  :clickhouse {:host host}))))))
+      (doall
+       (for [host ["myhost" "http://myhost" "https://myhost"]]
+        (testing (str "for host " host)
+          (is (= (merge ctd/default-connection-params
+                        {:subname "//myhost:8123/default"})
+                 (sql-jdbc.conn/connection-details->spec
+                  :clickhouse {:host host}))))))
+      (doall
+       (for [host ["sub.example.com" "http://sub.example.com" "https://sub.example.com"]]
+        (testing (str "for host " host " with some additional params")
+          (is (= (merge ctd/default-connection-params
+                        {:subname "//sub.example.com:8443/mydb" :ssl true})
+                 (sql-jdbc.conn/connection-details->spec
+                  :clickhouse {:host host :dbname "mydb" :port 8443 :ssl true})))))))))
 
 (deftest ^:parallel clickhouse-connection-string-select-sequential-consistency
   (mt/with-dynamic-fn-redefs [ ;; This function's implementation requires the connection details to actually

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -50,7 +50,7 @@
    :password ""
    :ssl false
    :use_server_time_zone_for_dates true
-   :product_name "metabase/1.53.2"
+   :product_name "metabase/1.53.3"
    :jdbc_ignore_unsupported_values "true"
    :jdbc_schema_term "schema",
    :max_open_connections 100


### PR DESCRIPTION
## Summary

While that was not technically correct and it was not an expected behavior, previously, it was possible to specify something like `http://myhost` in the `host` configuration option. This PR brings back the old behavior.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG