### PR TITLE
Revert to old type introspection for datetime

### DIFF
--- a/src/metabase/driver/clickhouse_introspection.clj
+++ b/src/metabase/driver/clickhouse_introspection.clj
@@ -54,10 +54,10 @@
     ;; :type/DateTime
     ;; DateTime64
     (str/starts-with? db-type "datetime64")
-    :type/DateTimeWithLocalTZ
+    (if (> (count db-type) 13) :type/DateTimeWithLocalTZ :type/DateTime)
     ;; DateTime
     (str/starts-with? db-type "datetime")
-    :type/DateTimeWithLocalTZ
+    (if (> (count db-type) 13) :type/DateTimeWithLocalTZ :type/DateTime)
     ;; Enum*
     (str/starts-with? db-type "enum")
     :type/Text


### PR DESCRIPTION
## Summary

The change of this logic in https://github.com/ClickHouse/metabase-clickhouse-driver/commit/5a6898c61364a15899c50d6b1ee852923303fd27 is responsible for the [following escalation](https://github.com/metabase/metabase/issues/55199).

It's worth noting that Metabase Uploads explicitly do not support zoned datetimes for Clickhouse, so the logic as it stands prevents users for appending *any* data to a table containing datetimes. 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
