### PR TITLE
Bump jdbc to 0.8.4

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
  :deps
  {com.widdindustries/cljc.java-time {:mvn/version "0.1.21"}
-  com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.2"}
+  com.clickhouse/clickhouse-jdbc {:mvn/version "0.8.4"}
   org.lz4/lz4-java {:mvn/version "1.8.0"}}}


### PR DESCRIPTION
## Summary

Bump ClickHouse JDBC driver version to 0.8.4.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
